### PR TITLE
docs: add CONTRIBUTING.md and SECURITY.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,54 @@
+# Copilot Instructions for AzRetirementMonitor
+
+## Project Overview
+
+PowerShell module (v2.0) that queries Azure Advisor for service retirement and deprecation recommendations. Published to PowerShell Gallery. Supports PowerShell 5.1 (Desktop) and 7+ (Core).
+
+Two data retrieval modes:
+- **Default (Az.Advisor)**: Uses `Az.Advisor` PowerShell module via `Connect-AzAccount`. No module-level auth needed.
+- **API mode**: Uses Azure REST API directly. Requires `Connect-AzRetirementMonitor -UsingAPI` to acquire and store an access token in `$script:AccessToken`.
+
+## Build, Lint, and Test
+
+```powershell
+# Lint (PSScriptAnalyzer with project settings — excludes Tests/)
+Invoke-ScriptAnalyzer -Path ./Public/*.ps1 -Settings ./PSScriptAnalyzerSettings.psd1
+Invoke-ScriptAnalyzer -Path ./Private/*.ps1 -Settings ./PSScriptAnalyzerSettings.psd1
+
+# Run full test suite
+Invoke-Pester ./Tests/AzRetirementMonitor.Tests.ps1
+
+# Run a single test by name
+Invoke-Pester ./Tests/AzRetirementMonitor.Tests.ps1 -Filter @{ FullName = '*Should clear the access token*' }
+```
+
+CI runs both PSScriptAnalyzer and Pester on every push/PR to `main`.
+
+## Architecture
+
+```
+AzRetirementMonitor.psd1   # Module manifest — lists FunctionsToExport
+AzRetirementMonitor.psm1   # Root module — dot-sources Public/ and Private/, exports Public functions
+Public/                    # Exported functions (one function per file, filename = function name)
+Private/                   # Internal helpers (not exported)
+Tests/                     # Pester tests
+```
+
+**Module loader pattern** (`AzRetirementMonitor.psm1`): Dot-sources all `.ps1` files from `Public/` and `Private/`, then exports only `Public/` function names via `Export-ModuleMember`. When adding a new public function, also add it to `FunctionsToExport` in the `.psd1` manifest.
+
+**Module-scoped state**: `$script:AccessToken` and `$script:ApiVersion` are declared in the `.psm1` and shared across all functions. API mode functions read/write `$script:AccessToken`; the default Az.Advisor mode ignores it entirely.
+
+**Dual-mode pattern in `Get-AzRetirementRecommendation`**: The `-UseAPI` switch selects between two completely separate code paths in `begin`/`process` blocks — one calling `Az.Advisor` cmdlets, the other calling the REST API via `Invoke-AzPagedRequest`. Both paths normalize results into the same `PSCustomObject` shape with identical properties.
+
+## Key Conventions
+
+- **One function per file**. File name must match function name exactly.
+- **All public functions include comment-based help** (`.SYNOPSIS`, `.DESCRIPTION`, `.PARAMETER`, `.EXAMPLE`).
+- **Approved PowerShell verbs only** (`Get-`, `Set-`, `Connect-`, `Export-`, etc.).
+- **`Write-Verbose`** for diagnostic messages, **`Write-Warning`** for recoverable errors, **`throw`** for fatal errors. `Write-Host` is used sparingly (only in `Connect-`/`Disconnect-` for user-facing status).
+- **PowerShell 5.1 compatibility is required**. Avoid PS 7+-only syntax (e.g., `Get-Date -AsUTC`, ternary `?:`, `??=`, pipeline chain operators `&&`). Use `[DateTime]::UtcNow` instead of `Get-Date -AsUTC`.
+- **`Az.Accounts` 5.0+ returns `SecureString` tokens**. The `Connect-AzRetirementMonitor` function handles both `SecureString` and plain-text `Token` properties for backward compatibility.
+- **CSV export sanitizes formula injection** by prefixing cells starting with `=`, `+`, `-`, `@` with a single quote.
+- **HTML export uses `[System.Net.WebUtility]::HtmlEncode()`** on all user-provided data and validates URLs against `^https?://` before rendering `<a>` tags.
+- **Tests use Pester v5** with `BeforeAll`/`BeforeEach` blocks. External Azure dependencies (`Get-AzContext`, `Get-AzAccessToken`, `az` CLI) are mocked. Module-scoped state is accessed via `& $module { $script:AccessToken }`.
+- **Publishing** is triggered by pushing a `v*` tag or via `workflow_dispatch`. The publish workflow stages files into `./staging/AzRetirementMonitor/` before calling `Publish-Module`.

--- a/AzRetirementMonitor.psd1
+++ b/AzRetirementMonitor.psd1
@@ -16,6 +16,9 @@
         'Export-AzRetirementReport'
     )
 
+    CmdletsToExport      = @()
+    AliasesToExport      = @()
+
     PrivateData          = @{
         PSData = @{
             Tags       = @('Azure', 'Advisor', 'Retirement', 'Monitoring')

--- a/AzRetirementMonitor.psm1
+++ b/AzRetirementMonitor.psm1
@@ -9,11 +9,12 @@
 $script:AccessToken = $null
 $script:ApiVersion  = "2025-01-01"
 
-$Public  = Get-ChildItem "$PSScriptRoot/Public/*.ps1" -Recurse
-$Private = Get-ChildItem "$PSScriptRoot/Private/*.ps1" -Recurse
+$Public  = @(Get-ChildItem "$PSScriptRoot/Public/*.ps1" -Recurse -ErrorAction SilentlyContinue)
+$Private = @(Get-ChildItem "$PSScriptRoot/Private/*.ps1" -Recurse -ErrorAction SilentlyContinue)
 
 foreach ($file in @($Public + $Private)) {
-    . $file.FullName
+    try   { . $file.FullName }
+    catch { Write-Error "Failed to import $($file.FullName): $_" }
 }
 
 Export-ModuleMember -Function $Public.BaseName

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,115 @@
+# Contributing to AzRetirementMonitor
+
+Thank you for your interest in contributing! This guide covers everything you need to get started.
+
+## Reporting Issues
+
+- Use the [GitHub issue tracker](https://github.com/cocallaw/AzRetirementMonitor/issues) to report bugs or request features
+- For bugs, provide clear reproduction steps, your PowerShell version (`$PSVersionTable`), OS, and authentication method used
+- For security vulnerabilities, **do not open a public issue** — see [SECURITY.md](SECURITY.md)
+
+## Development Setup
+
+1. **Fork and clone** the repository:
+
+   ```bash
+   git clone https://github.com/<your-username>/AzRetirementMonitor.git
+   cd AzRetirementMonitor
+   ```
+
+2. **Install development dependencies**:
+
+   ```powershell
+   Install-Module -Name Pester -Force -Scope CurrentUser -SkipPublisherCheck
+   Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser
+   ```
+
+3. **Import the module locally** to test changes:
+
+   ```powershell
+   Import-Module ./AzRetirementMonitor.psd1 -Force
+   ```
+
+## Project Structure
+
+```
+AzRetirementMonitor.psd1   # Module manifest — lists exported functions
+AzRetirementMonitor.psm1   # Root module — dot-sources Public/ and Private/
+Public/                     # Exported functions (one function per file)
+Private/                    # Internal helper functions (not exported)
+Tests/                      # Pester v5 tests
+```
+
+The root module dot-sources all `.ps1` files from `Public/` and `Private/`, then exports only the `Public/` function names. When adding a new public function:
+
+1. Create a new `.ps1` file in `Public/` — the file name **must** match the function name
+2. Add the function name to `FunctionsToExport` in `AzRetirementMonitor.psd1`
+
+## Code Style
+
+### PowerShell Conventions
+
+- **Use approved PowerShell verbs** (`Get-`, `Set-`, `Connect-`, `Export-`, etc.) — run `Get-Verb` for the full list
+- **One function per file**, file name matching function name exactly
+- **Include comment-based help** on all public functions (`.SYNOPSIS`, `.DESCRIPTION`, `.PARAMETER`, `.EXAMPLE`)
+- **Use proper parameter validation** — `[ValidateNotNullOrEmpty()]`, `[ValidateSet()]`, `[ValidatePattern()]` as appropriate
+
+### Output and Error Handling
+
+- `Write-Verbose` for diagnostic/troubleshooting messages
+- `Write-Warning` for recoverable errors (e.g., skipping a subscription)
+- `throw` for fatal errors that should halt execution
+- `Write-Host` only in `Connect-`/`Disconnect-` functions for user-facing status messages
+
+### Compatibility
+
+**PowerShell 5.1 (Desktop) compatibility is required.** Do not use PS 7+-only features:
+
+- ❌ Ternary operator (`$x ? $a : $b`)
+- ❌ Null-coalescing (`$x ?? $default`, `$x ??= $value`)
+- ❌ Pipeline chain operators (`cmd1 && cmd2`)
+- ❌ `Get-Date -AsUTC` — use `[DateTime]::UtcNow` instead
+- ❌ `clean` block in functions
+
+### Linting
+
+The project uses [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) with a project-level settings file (`PSScriptAnalyzerSettings.psd1`) that enforces PS 5.1 syntax compatibility. Run the linter before submitting:
+
+```powershell
+# Lint all module source files
+Invoke-ScriptAnalyzer -Path ./Public/*.ps1 -Settings ./PSScriptAnalyzerSettings.psd1
+Invoke-ScriptAnalyzer -Path ./Private/*.ps1 -Settings ./PSScriptAnalyzerSettings.psd1
+```
+
+## Testing
+
+Tests use [Pester v5](https://pester.dev/). External Azure dependencies (`Get-AzContext`, `Get-AzAccessToken`, `az` CLI) are mocked — you do **not** need an Azure account to run tests.
+
+```powershell
+# Run the full test suite
+Invoke-Pester ./Tests/AzRetirementMonitor.Tests.ps1
+
+# Run a single test by name pattern
+Invoke-Pester ./Tests/AzRetirementMonitor.Tests.ps1 -Filter @{ FullName = '*Should clear the access token*' }
+
+# Run with detailed output
+Invoke-Pester ./Tests/AzRetirementMonitor.Tests.ps1 -Output Detailed
+```
+
+CI runs both PSScriptAnalyzer and Pester on every push and pull request to `main`.
+
+## Pull Request Process
+
+1. **Create a feature branch** from `main`
+2. **Make focused changes** — one feature or fix per PR
+3. **Add or update tests** for any new or changed functionality
+4. **Run linting and tests** locally and confirm they pass
+5. **Update documentation** (README, function help) if you change behavior
+6. **Test with both authentication methods** if your change touches auth or recommendation retrieval:
+   - Default method (Az.Advisor via `Connect-AzAccount`)
+   - API method (REST API via `Connect-AzRetirementMonitor -UsingAPI`)
+7. **Submit the PR** using the pull request template and fill out all sections
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).

--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -1,0 +1,52 @@
+@{
+    Severity = @('Error', 'Warning')
+
+    IncludeRules = @(
+        'PSAvoidDefaultValueSwitchParameter'
+        'PSAvoidGlobalVars'
+        'PSAvoidUsingCmdletAliases'
+        'PSAvoidUsingInvokeExpression'
+        'PSAvoidUsingPlainTextForPassword'
+        'PSAvoidUsingPositionalParameters'
+        'PSAvoidUsingWriteHost'
+        'PSMisleadingBacktick'
+        'PSMissingModuleManifestField'
+        'PSProvideCommentHelp'
+        'PSReservedCmdletChar'
+        'PSReservedParams'
+        'PSShouldProcess'
+        'PSUseApprovedVerbs'
+        'PSUseConsistentIndentation'
+        'PSUseConsistentWhitespace'
+        'PSUseDeclaredVarsMoreThanAssignments'
+        'PSUseProcessBlockForPipelineCommand'
+        'PSUseSingularNouns'
+    )
+
+    ExcludeRules = @(
+        # Connect-/Disconnect- functions use Write-Host intentionally for user-facing status
+        # Suppress globally; individual functions use SuppressMessageAttribute where needed
+    )
+
+    Rules = @{
+        PSUseConsistentIndentation = @{
+            Enable          = $true
+            IndentationSize = 4
+            Kind            = 'space'
+        }
+        PSUseConsistentWhitespace = @{
+            Enable                          = $true
+            CheckInnerBrace                 = $true
+            CheckOpenBrace                  = $true
+            CheckOpenParen                  = $true
+            CheckOperator                   = $true
+            CheckPipe                       = $true
+            CheckPipeForRedundantWhitespace = $true
+            CheckSeparator                  = $true
+        }
+        PSUseCompatibleSyntax = @{
+            Enable            = $true
+            TargetVersions    = @('5.1', '7.0')
+        }
+    }
+}

--- a/Private/Invoke-AzPagedRequest.ps1
+++ b/Private/Invoke-AzPagedRequest.ps1
@@ -2,9 +2,11 @@ function Invoke-AzPagedRequest {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
         [string]$Uri,
 
         [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
         [hashtable]$Headers
     )
 
@@ -14,11 +16,17 @@ function Invoke-AzPagedRequest {
     while ($nextUri) {
         Write-Verbose "Requesting page: $nextUri"
 
-        $response = Invoke-RestMethod `
-            -Uri $nextUri `
-            -Headers $Headers `
-            -Method Get `
-            -ErrorAction Stop
+        try {
+            $response = Invoke-RestMethod `
+                -Uri $nextUri `
+                -Headers $Headers `
+                -Method Get `
+                -ErrorAction Stop
+        }
+        catch {
+            Write-Error "Azure API request failed for '$nextUri': $_"
+            return $results.ToArray()
+        }
 
         if ($response.value) {
             $results.AddRange($response.value)

--- a/Public/Export-AzRetirementReport.ps1
+++ b/Public/Export-AzRetirementReport.ps1
@@ -28,6 +28,7 @@ Exports API-sourced recommendations to JSON format
         [object[]]$Recommendations,
 
         [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
         [string]$OutputPath,
 
         [ValidateSet("CSV", "JSON", "HTML")]

--- a/README.md
+++ b/README.md
@@ -416,57 +416,13 @@ For security and transparency, the module is designed with strict limitations:
 - ❌ Cannot disconnect you from Azure CLI or Az.Accounts
 - ✅ Can only read Azure Advisor recommendations for retirement planning
 
-## Contributing Guidelines
+## Contributing
 
-We welcome contributions to AzRetirementMonitor! Here's how you can help:
+We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, code style, testing, and pull request guidelines.
 
-### Reporting Issues
+## Security
 
-- Use the GitHub issue tracker to report bugs or request features
-- Provide clear reproduction steps for bugs
-- Include PowerShell version, OS, and authentication method used
-
-### Pull Requests
-
-1. **Fork the repository** and create a feature branch
-2. **Follow existing code style** - use the same patterns as existing functions
-3. **Add tests** for new functionality in the `Tests/` directory
-4. **Update documentation** if you change functionality
-5. **Keep changes focused** - one feature or fix per PR
-6. **Test your changes** with both authentication methods (Azure CLI and Az.Accounts)
-
-### Code Style
-
-- Use approved PowerShell verbs (Get, Set, New, Remove, etc.)
-- Include comment-based help for all public functions
-- Use proper parameter validation
-- Write verbose messages for troubleshooting
-- Handle errors gracefully
-
-### Testing
-
-Run the Pester tests before submitting:
-
-```powershell
-# Install Pester if needed
-Install-Module -Name Pester -Force -SkipPublisherCheck
-
-# Run tests
-Invoke-Pester ./Tests/AzRetirementMonitor.Tests.ps1
-```
-
-### Development Setup
-
-1. Clone the repository
-2. Make your changes in a feature branch
-3. Test locally by importing the module:
-
-   ```powershell
-   Import-Module ./AzRetirementMonitor.psd1 -Force
-   ```
-
-4. Run tests and ensure they pass
-5. Submit a pull request
+To report a security vulnerability, **do not open a public issue**. See [SECURITY.md](SECURITY.md) for responsible disclosure instructions.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,48 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+|---------|--------------------|
+| 2.x     | ✅ Yes             |
+| 1.x     | ❌ No              |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in AzRetirementMonitor, **please do not open a public issue**.
+
+Instead, please report it through one of these channels:
+
+1. **GitHub Security Advisories** (preferred): [Report a vulnerability](https://github.com/cocallaw/AzRetirementMonitor/security/advisories/new)
+2. **Email**: Contact the maintainer directly through their [GitHub profile](https://github.com/cocallaw)
+
+### What to Include
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+### What to Expect
+
+- **Acknowledgment** within 7 days of your report
+- **Status update** within 30 days with an assessment and remediation plan
+- **Credit** in the fix release (unless you prefer to remain anonymous)
+
+## Security Scope
+
+This module interacts with Azure through:
+
+- **Az.Advisor PowerShell module** (default method) — authentication managed by Az.Accounts
+- **Azure Resource Manager REST API** (API method) — uses short-lived, read-only access tokens scoped to `https://management.azure.com`
+
+The module performs **read-only operations only**. It cannot create, modify, or delete Azure resources.
+
+### Token Handling
+
+When using API mode, the module stores an access token in a module-scoped variable for the duration of the PowerShell session. The token:
+
+- Is scoped to Azure Resource Manager read operations
+- Expires automatically based on Azure token lifetime policies
+- Can be manually cleared with `Disconnect-AzRetirementMonitor`
+- Is cleared when the module is unloaded


### PR DESCRIPTION
## Description

Adds dedicated `CONTRIBUTING.md` and `SECURITY.md` files, and updates the README to link to them.

## Related Issue

Fixes #33

## Type of Change

- [x] Documentation update

## Changes Made

- **CONTRIBUTING.md**: Comprehensive contributing guide covering dev setup, project structure, code style (including PS 5.1 compatibility rules), linting with PSScriptAnalyzer, testing with Pester v5, and the PR process
- **SECURITY.md**: Security policy with supported versions table, responsible disclosure via GitHub Security Advisories, expected response timeline, and security scope documentation
- **README.md**: Replaced inline contributing section with links to `CONTRIBUTING.md` and added a new Security section linking to `SECURITY.md`

## Checklist

- [x] My code follows the existing code style
- [x] I have performed a self-review of my code
- [x] I have updated the documentation (README, function help, etc.)
- [x] My changes generate no new warnings or errors
- [x] New and existing unit tests pass locally