### PR TITLE
fix: validate SubscriptionId parameter as GUID format

### DIFF
--- a/Public/Get-AzRetirementRecommendation.ps1
+++ b/Public/Get-AzRetirementRecommendation.ps1
@@ -31,6 +31,7 @@ Gets recommendations using the REST API method
     [CmdletBinding()]
     param(
         [Parameter(ValueFromPipeline)]
+        [ValidatePattern('^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$')]
         [string[]]$SubscriptionId,
 
         [Parameter()]

--- a/Tests/AzRetirementMonitor.Tests.ps1
+++ b/Tests/AzRetirementMonitor.Tests.ps1
@@ -190,6 +190,28 @@ Describe "Get-AzRetirementRecommendation" {
         $param.Attributes.Where({$_.ValueFromPipeline}).Count | Should -BeGreaterThan 0
     }
     
+    It "Should validate SubscriptionId as a GUID format" {
+        $cmd = Get-Command Get-AzRetirementRecommendation
+        $param = $cmd.Parameters['SubscriptionId']
+        $validatePattern = $param.Attributes.Where({$_ -is [System.Management.Automation.ValidatePatternAttribute]})
+        $validatePattern.Count | Should -BeGreaterThan 0
+    }
+
+    It "Should reject an invalid SubscriptionId" {
+        { Get-AzRetirementRecommendation -SubscriptionId "not-a-guid" } | Should -Throw
+    }
+
+    It "Should reject a SubscriptionId with path traversal characters" {
+        { Get-AzRetirementRecommendation -SubscriptionId "../../malicious" } | Should -Throw
+    }
+
+    It "Should accept a valid GUID SubscriptionId format" {
+        $cmd = Get-Command Get-AzRetirementRecommendation
+        $param = $cmd.Parameters['SubscriptionId']
+        $pattern = ($param.Attributes.Where({$_ -is [System.Management.Automation.ValidatePatternAttribute]}))[0].RegexPattern
+        "12345678-1234-1234-1234-123456789012" -match $pattern | Should -Be $true
+    }
+    
     It "Should not have Category parameter" {
         $cmd = Get-Command Get-AzRetirementRecommendation
         $cmd.Parameters.ContainsKey('Category') | Should -Be $false

--- a/Tests/AzRetirementMonitor.Tests.ps1
+++ b/Tests/AzRetirementMonitor.Tests.ps1
@@ -198,18 +198,44 @@ Describe "Get-AzRetirementRecommendation" {
     }
 
     It "Should reject an invalid SubscriptionId" {
-        { Get-AzRetirementRecommendation -SubscriptionId "not-a-guid" } | Should -Throw
+        $errorRecord = $null
+
+        try {
+            Get-AzRetirementRecommendation -SubscriptionId "not-a-guid" -ErrorAction Stop
+            throw "Expected parameter validation to fail for SubscriptionId"
+        }
+        catch {
+            $errorRecord = $_
+        }
+
+        $errorRecord | Should -Not -BeNullOrEmpty
+        $errorRecord.Exception.Message | Should -Match "Cannot validate argument on parameter 'SubscriptionId'"
+        $errorRecord.FullyQualifiedErrorId | Should -Match "ParameterArgumentValidationError"
     }
 
     It "Should reject a SubscriptionId with path traversal characters" {
-        { Get-AzRetirementRecommendation -SubscriptionId "../../malicious" } | Should -Throw
+        $errorRecord = $null
+
+        try {
+            Get-AzRetirementRecommendation -SubscriptionId "../../malicious" -ErrorAction Stop
+            throw "Expected parameter validation to fail for SubscriptionId"
+        }
+        catch {
+            $errorRecord = $_
+        }
+
+        $errorRecord | Should -Not -BeNullOrEmpty
+        $errorRecord.Exception.Message | Should -Match "Cannot validate argument on parameter 'SubscriptionId'"
+        $errorRecord.FullyQualifiedErrorId | Should -Match "ParameterArgumentValidationError"
     }
 
     It "Should accept a valid GUID SubscriptionId format" {
         $cmd = Get-Command Get-AzRetirementRecommendation
         $param = $cmd.Parameters['SubscriptionId']
-        $pattern = ($param.Attributes.Where({$_ -is [System.Management.Automation.ValidatePatternAttribute]}))[0].RegexPattern
-        "12345678-1234-1234-1234-123456789012" -match $pattern | Should -Be $true
+        $validatePatterns = $param.Attributes.Where({$_ -is [System.Management.Automation.ValidatePatternAttribute]})
+        $validatePatterns.Count | Should -BeGreaterThan 0
+        $pattern = $validatePatterns[0].RegexPattern
+        $pattern | Should -Be '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
     }
     
     It "Should not have Category parameter" {


### PR DESCRIPTION
## Description

Adds `ValidatePattern` attribute to the `SubscriptionId` parameter on `Get-AzRetirementRecommendation` to enforce GUID format, preventing malformed ARM API URLs and bogus portal links from invalid input.

## Related Issue

Fixes #26

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Added `[ValidatePattern]` for GUID format (`^[0-9a-fA-F]{8}-...`) to `$SubscriptionId` in `Get-AzRetirementRecommendation`
- Added 4 Pester tests:
  - Validates the `ValidatePattern` attribute is present
  - Rejects invalid subscription IDs
  - Rejects path traversal strings
  - Accepts valid GUID format

## Testing

- [x] All existing tests pass
- [x] Added/updated unit tests

### Test Results

```
Tests Passed: 53, Failed: 0, Skipped: 0
```

## Checklist

- [x] My code follows the existing code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally
- [x] I have checked for any breaking changes