### PR TITLE
ci: add Windows PowerShell 5.1 test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,31 +7,26 @@ on:
     branches: [ main, master ]
 
 jobs:
-  lint-and-test:
-    name: Lint and Test PowerShell Module
+  lint:
+    name: Lint PowerShell Module
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
-      - name: Setup PowerShell
-        shell: pwsh
-        run: |
-          Write-Host "PowerShell version: $($PSVersionTable.PSVersion)"
-      
+
       - name: Install PSScriptAnalyzer
         shell: pwsh
         run: |
           Set-PSRepository PSGallery -InstallationPolicy Trusted
           Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser
-      
+
       - name: Run PSScriptAnalyzer
         shell: pwsh
         run: |
-          $scriptFiles = Get-ChildItem -Path . -Recurse -Include *.ps1 | Where-Object { $_.FullName -notmatch '/Tests/' }
+          $scriptFiles = Get-ChildItem -Path . -Recurse -Include *.ps1,*.psm1 | Where-Object { $_.FullName -notmatch '[/\\]Tests[/\\]' }
           if ($scriptFiles) {
             $results = $scriptFiles | ForEach-Object { Invoke-ScriptAnalyzer -Path $_.FullName -Settings PSGallery }
           } else {
@@ -44,15 +39,56 @@ jobs:
           } else {
             Write-Host "No issues found by PSScriptAnalyzer"
           }
-      
+
+  test:
+    name: Test (${{ matrix.os }}, ${{ matrix.shell }})
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            shell: pwsh
+          - os: windows-latest
+            shell: powershell
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Print PowerShell version
+        shell: ${{ matrix.shell }}
+        run: |
+          Write-Host "PowerShell version: $($PSVersionTable.PSVersion)"
+          Write-Host "PSEdition: $($PSVersionTable.PSEdition)"
+
+      - name: Verify expected PowerShell edition
+        if: matrix.shell == 'powershell'
+        shell: powershell
+        run: |
+          if ($PSVersionTable.PSEdition -ne 'Desktop') {
+            Write-Error "Expected PSEdition 'Desktop' but got '$($PSVersionTable.PSEdition)'"
+            exit 1
+          }
+          if ($PSVersionTable.PSVersion.Major -ne 5) {
+            Write-Error "Expected PowerShell 5.x but got $($PSVersionTable.PSVersion)"
+            exit 1
+          }
+          Write-Host "Confirmed: Windows PowerShell $($PSVersionTable.PSVersion) Desktop"
+
       - name: Install Pester
-        shell: pwsh
+        shell: ${{ matrix.shell }}
         run: |
-          Install-Module -Name Pester -Force -Scope CurrentUser -SkipPublisherCheck
-      
+          Set-PSRepository PSGallery -InstallationPolicy Trusted
+          Install-Module -Name Pester -MinimumVersion 5.0.0 -Force -Scope CurrentUser -SkipPublisherCheck
+
       - name: Run Pester Tests
-        shell: pwsh
+        shell: ${{ matrix.shell }}
         run: |
+          Import-Module Pester -MinimumVersion 5.0.0
+          Write-Host "Pester version: $((Get-Module Pester).Version)"
           $testPath = "Tests/AzRetirementMonitor.Tests.ps1"
           if (Test-Path $testPath) {
             $config = New-PesterConfiguration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,12 +82,12 @@ jobs:
         shell: ${{ matrix.shell }}
         run: |
           Set-PSRepository PSGallery -InstallationPolicy Trusted
-          Install-Module -Name Pester -MinimumVersion 5.0.0 -Force -Scope CurrentUser -SkipPublisherCheck
+          Install-Module -Name Pester -MinimumVersion 5.0.0 -MaximumVersion 5.99.99 -Force -Scope CurrentUser -SkipPublisherCheck
 
       - name: Run Pester Tests
         shell: ${{ matrix.shell }}
         run: |
-          Import-Module Pester -MinimumVersion 5.0.0
+          Import-Module Pester -MinimumVersion 5.0.0 -MaximumVersion 5.99.99
           Write-Host "Pester version: $((Get-Module Pester).Version)"
           $testPath = "Tests/AzRetirementMonitor.Tests.ps1"
           if (Test-Path $testPath) {

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Run PSScriptAnalyzer (Pre-publish validation)
         shell: pwsh
         run: |
-          $scriptFiles = Get-ChildItem -Path . -Recurse -Include *.ps1 | Where-Object { $_.FullName -notmatch '/Tests/' }
+          $scriptFiles = Get-ChildItem -Path . -Recurse -Include *.ps1,*.psm1 | Where-Object { $_.FullName -notmatch '[/\\]Tests[/\\]' }
           if ($scriptFiles) {
             $results = $scriptFiles | ForEach-Object { Invoke-ScriptAnalyzer -Path $_.FullName -Settings PSGallery }
           } else {

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # AzRetirementMonitor
 
+[![CI](https://github.com/cocallaw/AzRetirementMonitor/actions/workflows/ci.yml/badge.svg)](https://github.com/cocallaw/AzRetirementMonitor/actions/workflows/ci.yml)
+
 A PowerShell module for monitoring Azure service retirements and deprecation notices using Azure Advisor recommendations.
 
 ## What Problem Does This Solve?


### PR DESCRIPTION
## Summary

Adds a Windows PowerShell 5.1 test matrix to CI and a CI status badge to the README.

Closes #31
Closes #42

## Changes

**ci.yml** — split into two parallel jobs:

| Job | Runner | Shell | Purpose |
|-----|--------|-------|---------|
| `lint` | ubuntu-latest | pwsh | PSScriptAnalyzer (runs once) |
| `test` (leg 1) | ubuntu-latest | pwsh | Pester on PS Core |
| `test` (leg 2) | windows-latest | powershell | Pester on PS 5.1 Desktop |

Additional improvements:
- **Lint now scans `.psm1` files** in addition to `.ps1`
- **Path regex fixed** for cross-platform: `[/\\]Tests[/\\]` instead of `/Tests/`
- **Pester pinned** to `MinimumVersion 5.0.0` to prevent future breakage
- **Edition assertion** on the Windows leg to guard against runner image changes
- `fail-fast: false` so both legs always run

**publish.yml** — same path regex and `.psm1` lint fixes applied for consistency.

**README.md** — added CI status badge at the top.

## Testing

YAML validated. The Windows leg will confirm PS 5.1 Desktop on first CI run.