### PR TITLE
ci: fix matrix definition to resolve workflow validation errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
+        os: [ubuntu-latest, windows-latest]
+        shell: [pwsh, powershell]
+        exclude:
           - os: ubuntu-latest
-            shell: pwsh
-          - os: windows-latest
             shell: powershell
+          - os: windows-latest
+            shell: pwsh
 
     steps:
       - name: Checkout code
@@ -65,7 +67,7 @@ jobs:
           Write-Host "PSEdition: $($PSVersionTable.PSEdition)"
 
       - name: Verify expected PowerShell edition
-        if: matrix.shell == 'powershell'
+        if: ${{ matrix.shell == 'powershell' }}
         shell: powershell
         run: |
           if ($PSVersionTable.PSEdition -ne 'Desktop') {


### PR DESCRIPTION
## Summary

Fixes the GitHub Actions workflow validation error:
```
Unrecognized named-value: 'matrix'
```

## Root Cause

The `include`-only matrix syntax caused GitHub Actions to not recognize `matrix.shell` and `matrix.os` as valid context variables. The validator requires explicitly declared matrix variables.

## Fix

- Switch from `include`-only to explicit `os`/`shell` arrays with `exclude` for invalid combinations (ubuntu+powershell, windows+pwsh)
- Fix `if:` condition to use `${{ }}` expression syntax

## Result

Same 2-leg matrix (ubuntu/pwsh + windows/powershell), now with proper variable declarations.