### PR TITLE
fix: address high-priority security issues #23 and #40

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,6 +60,27 @@ jobs:
             Write-Host "No issues found by PSScriptAnalyzer"
           }
       
+      - name: Install Pester (Pre-publish validation)
+        shell: pwsh
+        run: |
+          Install-Module -Name Pester -MinimumVersion 5.0.0 -MaximumVersion 5.99.99 -Force -Scope CurrentUser -SkipPublisherCheck
+
+      - name: Run Pester Tests (Pre-publish validation)
+        shell: pwsh
+        run: |
+          Import-Module Pester -MinimumVersion 5.0.0 -MaximumVersion 5.99.99
+          $testPath = "Tests/AzRetirementMonitor.Tests.ps1"
+          if (Test-Path $testPath) {
+            $config = New-PesterConfiguration
+            $config.Run.Path = $testPath
+            $config.Run.Exit = $true
+            $config.Output.Verbosity = 'Detailed'
+            Invoke-Pester -Configuration $config
+          } else {
+            Write-Error "Test file not found at: $testPath"
+            exit 1
+          }
+
       - name: Prepare Module for Publishing
         shell: pwsh
         run: |

--- a/Public/Connect-AzRetirementMonitor.ps1
+++ b/Public/Connect-AzRetirementMonitor.ps1
@@ -55,6 +55,9 @@ None. Displays a success message when authentication completes.
     Write-Verbose "This connection is only needed when using Get-AzRetirementRecommendation -UseAPI"
 
     try {
+        # Clear any previously stored token so a failure never leaves a stale token in scope
+        $script:AccessToken = $null
+
         if ($UseAzPowerShell) {
             if (-not (Get-Module -ListAvailable -Name Az.Accounts)) {
                 throw "Az.Accounts module is not installed."

--- a/Public/Connect-AzRetirementMonitor.ps1
+++ b/Public/Connect-AzRetirementMonitor.ps1
@@ -81,6 +81,11 @@ None. Displays a success message when authentication completes.
                 # Backwards compatibility for older Az.Accounts versions that return plain text
                 $script:AccessToken = $token.Token
             }
+
+            if ([string]::IsNullOrWhiteSpace($script:AccessToken)) {
+                $script:AccessToken = $null
+                throw "Failed to acquire access token from Az.Accounts. Ensure you are connected with 'Connect-AzAccount'."
+            }
         }
         else {
             $null = & az account show 2>$null
@@ -93,6 +98,11 @@ None. Displays a success message when authentication completes.
                 --resource https://management.azure.com `
                 --query accessToken `
                 --output tsv
+
+            if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($script:AccessToken)) {
+                $script:AccessToken = $null
+                throw "Failed to acquire access token from Azure CLI. Ensure you are logged in with 'az login' and have access to the target subscription."
+            }
         }
 
         Write-Host "Authenticated to Azure successfully for API access"

--- a/Tests/AzRetirementMonitor.Tests.ps1
+++ b/Tests/AzRetirementMonitor.Tests.ps1
@@ -146,19 +146,19 @@ Describe "Connect-AzRetirementMonitor SecureString Handling" {
 
 Describe "Connect-AzRetirementMonitor Token Validation" {
     BeforeAll {
-        $script:CreatedStubs = @()
+        $script:TokenValidationCreatedStubs = @()
         if (-not (Get-Command Get-AzContext -ErrorAction SilentlyContinue)) {
             function global:Get-AzContext { }
-            $script:CreatedStubs += 'Get-AzContext'
+            $script:TokenValidationCreatedStubs += 'Get-AzContext'
         }
         if (-not (Get-Command Get-AzAccessToken -ErrorAction SilentlyContinue)) {
             function global:Get-AzAccessToken { }
-            $script:CreatedStubs += 'Get-AzAccessToken'
+            $script:TokenValidationCreatedStubs += 'Get-AzAccessToken'
         }
     }
 
     AfterAll {
-        foreach ($stubName in $script:CreatedStubs) {
+        foreach ($stubName in $script:TokenValidationCreatedStubs) {
             Remove-Item "Function:\$stubName" -ErrorAction SilentlyContinue
         }
     }

--- a/Tests/AzRetirementMonitor.Tests.ps1
+++ b/Tests/AzRetirementMonitor.Tests.ps1
@@ -144,6 +144,74 @@ Describe "Connect-AzRetirementMonitor SecureString Handling" {
     }
 }
 
+Describe "Connect-AzRetirementMonitor Token Validation" {
+    BeforeAll {
+        $script:CreatedStubs = @()
+        if (-not (Get-Command Get-AzContext -ErrorAction SilentlyContinue)) {
+            function global:Get-AzContext { }
+            $script:CreatedStubs += 'Get-AzContext'
+        }
+        if (-not (Get-Command Get-AzAccessToken -ErrorAction SilentlyContinue)) {
+            function global:Get-AzAccessToken { }
+            $script:CreatedStubs += 'Get-AzAccessToken'
+        }
+    }
+
+    AfterAll {
+        foreach ($stubName in $script:CreatedStubs) {
+            Remove-Item "Function:\$stubName" -ErrorAction SilentlyContinue
+        }
+    }
+
+    BeforeEach {
+        $module = Get-Module AzRetirementMonitor
+        & $module { $script:AccessToken = $null }
+    }
+
+    Context "Azure CLI path returns empty token" {
+        It "Should report error when az account get-access-token returns empty string" {
+            Mock -ModuleName AzRetirementMonitor -CommandName 'az' -MockWith {
+                $global:LASTEXITCODE = 0
+                return ''
+            }
+
+            Connect-AzRetirementMonitor -UsingAPI -ErrorVariable connectError -ErrorAction SilentlyContinue
+            $connectError | Should -Not -BeNullOrEmpty
+            $connectError[0].Exception.Message | Should -BeLike "*Failed to acquire access token*"
+
+            $module = Get-Module AzRetirementMonitor
+            $storedToken = & $module { $script:AccessToken }
+            $storedToken | Should -BeNullOrEmpty
+        }
+    }
+
+    Context "Az.Accounts path returns empty token" {
+        It "Should report error when Get-AzAccessToken returns null token" {
+            Mock -ModuleName AzRetirementMonitor Get-Module -ParameterFilter { $Name -eq 'Az.Accounts' -and $ListAvailable } {
+                return @{ Name = 'Az.Accounts'; Version = '5.0.0' }
+            }
+            Mock -ModuleName AzRetirementMonitor Import-Module { }
+            Mock -ModuleName AzRetirementMonitor Get-AzContext {
+                return @{ Account = @{ Id = "test@example.com" } }
+            }
+            Mock -ModuleName AzRetirementMonitor Get-AzAccessToken {
+                return [PSCustomObject]@{
+                    Token = $null
+                    ExpiresOn = [DateTimeOffset]::UtcNow.AddHours(1)
+                }
+            }
+
+            Connect-AzRetirementMonitor -UsingAPI -UseAzPowerShell -ErrorVariable connectError -ErrorAction SilentlyContinue
+            $connectError | Should -Not -BeNullOrEmpty
+            $connectError[0].Exception.Message | Should -BeLike "*Failed to acquire access token*"
+
+            $module = Get-Module AzRetirementMonitor
+            $storedToken = & $module { $script:AccessToken }
+            $storedToken | Should -BeNullOrEmpty
+        }
+    }
+}
+
 Describe "Disconnect-AzRetirementMonitor" {
     BeforeEach {
         # Clear the token before each test


### PR DESCRIPTION
## Summary

Addresses both high-priority security issues.

Closes #23
Closes #40

## Changes

### #23 — Validate token acquisition before reporting success

**`Public/Connect-AzRetirementMonitor.ps1`**:
- **Azure CLI path**: After `az account get-access-token`, checks `$LASTEXITCODE` and validates the token is non-empty. Clears `$script:AccessToken` and throws on failure.
- **Az.Accounts path**: After SecureString conversion or plain text assignment, validates the extracted token is non-empty. Same cleanup/throw on failure.

**`Tests/AzRetirementMonitor.Tests.ps1`**:
- Added `Connect-AzRetirementMonitor Token Validation` describe block with tests for both failure paths (empty CLI token, null Az.Accounts token).

### #40 — Add Pester tests to publish workflow

**`.github/workflows/publish.yml`**:
- Added Pester install and test steps between PSScriptAnalyzer and module staging.
- Pester version pinned to 5.x (matching ci.yml).
- A failing test suite now blocks publication to PSGallery.

## Testing

Full Pester suite: **55 tests passed, 0 failed** (including 2 new tests for #23).