### PR TITLE
Add Logic to Limit Max Pages Parsed

### DIFF
--- a/Private/Invoke-AzPagedRequest.ps1
+++ b/Private/Invoke-AzPagedRequest.ps1
@@ -6,26 +6,36 @@ function Invoke-AzPagedRequest {
 
         [Parameter(Mandatory)]
         [hashtable]$Headers
+
+        [Parameter()]
+        [int]$PageLimit = 100
     )
 
     $results = [System.Collections.Generic.List[object]]::new()
     $nextUri = $Uri
+    $pageCount = 0
 
     while ($nextUri) {
-        Write-Verbose "Requesting page: $nextUri"
-
-        $response = Invoke-RestMethod `
-            -Uri $nextUri `
-            -Headers $Headers `
-            -Method Get `
-            -ErrorAction Stop
-
-        if ($response.value) {
-            $results.AddRange($response.value)
+        $pageCount++
+        if ($pageCount -gt $PageLimit){
+            Write-Warning "Pagination limit ($MaxPages pages) reached. Results may be incomplete."
+            break
         }
+        else{
+            Write-Verbose "Requesting page: $nextUri"
+            $response = Invoke-RestMethod `
+                -Uri $nextUri `
+                -Headers $Headers `
+                -Method Get `
+                -ErrorAction Stop
 
-        $nextUri = $response.nextLink
-    }
+            if ($response.value) {
+                $results.AddRange($response.value)
+                }
+
+            $nextUri = $response.nextLink
+            }
+        }
 
     return $results.ToArray()
 }

--- a/Private/Invoke-AzPagedRequest.ps1
+++ b/Private/Invoke-AzPagedRequest.ps1
@@ -17,11 +17,11 @@ function Invoke-AzPagedRequest {
 
     while ($nextUri) {
         $pageCount++
-        if ($pageCount -gt $PageLimit){
+        if ($pageCount -gt $PageLimit) {
             Write-Warning "Pagination limit ($MaxPages pages) reached. Results may be incomplete."
             break
         }
-        else{
+        else {
             Write-Verbose "Requesting page: $nextUri"
             $response = Invoke-RestMethod `
                 -Uri $nextUri `
@@ -31,11 +31,11 @@ function Invoke-AzPagedRequest {
 
             if ($response.value) {
                 $results.AddRange($response.value)
-                }
+            }
 
             $nextUri = $response.nextLink
-            }
         }
+    }
 
     return $results.ToArray()
 }

--- a/Private/Invoke-AzPagedRequest.ps1
+++ b/Private/Invoke-AzPagedRequest.ps1
@@ -5,7 +5,7 @@ function Invoke-AzPagedRequest {
         [string]$Uri,
 
         [Parameter(Mandatory)]
-        [hashtable]$Headers
+        [hashtable]$Headers,
 
         [Parameter()]
         [int]$PageLimit = 100
@@ -18,7 +18,7 @@ function Invoke-AzPagedRequest {
     while ($nextUri) {
         $pageCount++
         if ($pageCount -gt $PageLimit) {
-            Write-Warning "Pagination limit ($MaxPages pages) reached. Results may be incomplete."
+            Write-Warning "Pagination limit ($PageLimit pages) reached. Results may be incomplete."
             break
         }
         else {


### PR DESCRIPTION
## Description

<!-- Provide a clear description of the changes in this PR -->

## Related Issue

<!-- Link to the issue this PR addresses, if applicable -->
Fixes https://github.com/cocallaw/AzRetirementMonitor/issues/38

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [x] Performance improvement
- [ ] Test updates

## Changes Made
This pull request introduces a configurable pagination limit to the `Invoke-AzPagedRequest` function, helping prevent excessive API calls and potential infinite loops during paginated requests. The main change is the addition of a `$PageLimit` parameter with a default value, along with logic to enforce this limit and warn the user if it is reached.

**Pagination improvements:**

* Added an optional `$PageLimit` parameter (default: 100) to `Invoke-AzPagedRequest`, allowing users to control the maximum number of pages fetched in a paginated API request.
* Implemented logic to track the number of pages fetched and stop pagination with a warning if the limit is exceeded, helping avoid infinite loops and excessive API calls.

## Testing

<!-- Describe the testing you've performed -->

- [ ] Tested with Azure CLI authentication
- [ ] Tested with Az.Accounts authentication
- [ ] Tested across multiple subscriptions
- [ ] Added/updated unit tests
- [ ] All existing tests pass

## Checklist

- [x] My code follows the existing code style
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation (README, function help, etc.)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [x] I have checked for any breaking changes

