### PR TITLE
24 security pagination follows nextlink urls without origin validation

### DIFF
--- a/Private/Invoke-AzPagedRequest.ps1
+++ b/Private/Invoke-AzPagedRequest.ps1
@@ -37,14 +37,28 @@ function Invoke-AzPagedRequest {
             if ($response.nextLink){
                 $parsedUri = $null
                 if (-not [System.Uri]::TryCreate($response.nextLink, [System.UriKind]::Absolute, [ref]$parsedUri)) {
-                    Write-Error "Malformed nextLink returned by service. Stopping pagination."
-                    break
+            if ($response.nextLink) {
+                $parsedUri = $null
+                $isValidNextLink = [System.Uri]::TryCreate(
+                    $response.nextLink,
+                    [System.UriKind]::Absolute,
+                    [ref]$parsedUri
+                )
+
+                if (-not $isValidNextLink) {
+                    throw "Invalid nextLink URI: $($response.nextLink). Stopping pagination."
                 }
+
                 # Verify that URI returned is secure and in the list of $allowedHosts
-                if ($parsedUri.Scheme -ne "https" -or $parsedUri.Host -notin $allowedHosts) {
+                if ($parsedUri.Scheme -ne "https") {
+                    throw "Insecure nextLink scheme: $($parsedUri.Scheme). Stopping pagination."
+                }
+
+                if ($parsedUri.Host -notin $allowedHosts) {
                     throw "Untrusted nextLink host: $($parsedUri.Host). Stopping pagination."
                 }
-                $nextUri = $response.nextLink
+
+                $nextUri = $parsedUri.AbsoluteUri
             } else {
                 $nextUri = $null
             }

--- a/Private/Invoke-AzPagedRequest.ps1
+++ b/Private/Invoke-AzPagedRequest.ps1
@@ -12,6 +12,7 @@ function Invoke-AzPagedRequest {
     )
 
     $results = [System.Collections.Generic.List[object]]::new()
+    $allowedHosts = @("management.azure.com")
     $nextUri = $Uri
     $pageCount = 0
 

--- a/Private/Invoke-AzPagedRequest.ps1
+++ b/Private/Invoke-AzPagedRequest.ps1
@@ -34,10 +34,6 @@ function Invoke-AzPagedRequest {
                 $results.AddRange($response.value)
             }
 
-            if ($response.nextLink){
-                $parsedUri = $null
-                # Verify that URI is not malformed
-                if (-not [System.Uri]::TryCreate($response.nextLink, [System.UriKind]::Absolute, [ref]$parsedUri)) {
             if ($response.nextLink) {
                 $parsedUri = $null
                 $isValidNextLink = [System.Uri]::TryCreate(
@@ -47,16 +43,19 @@ function Invoke-AzPagedRequest {
                 )
 
                 if (-not $isValidNextLink) {
-                    throw "Invalid nextLink URI: $($response.nextLink). Stopping pagination."
+                    Write-Error "Invalid nextLink URI: $($response.nextLink). Stopping pagination."
+                    break
                 }
 
                 # Verify that URI returned is secure and in the list of $allowedHosts
                 if ($parsedUri.Scheme -ne "https") {
-                    throw "Insecure nextLink scheme: $($parsedUri.Scheme). Stopping pagination."
+                    Write-Error "Insecure nextLink scheme: $($parsedUri.Scheme). Stopping pagination."
+                    break
                 }
 
                 if ($parsedUri.Host -notin $allowedHosts) {
-                    throw "Untrusted nextLink host: $($parsedUri.Host). Stopping pagination."
+                    Write-Error "Untrusted nextLink host: $($parsedUri.Host). Stopping pagination."
+                    break
                 }
 
                 $nextUri = $parsedUri.AbsoluteUri

--- a/Private/Invoke-AzPagedRequest.ps1
+++ b/Private/Invoke-AzPagedRequest.ps1
@@ -36,6 +36,7 @@ function Invoke-AzPagedRequest {
 
             if ($response.nextLink){
                 $parsedUri = $null
+                # Verify that URI is not malformed
                 if (-not [System.Uri]::TryCreate($response.nextLink, [System.UriKind]::Absolute, [ref]$parsedUri)) {
             if ($response.nextLink) {
                 $parsedUri = $null

--- a/Private/Invoke-AzPagedRequest.ps1
+++ b/Private/Invoke-AzPagedRequest.ps1
@@ -35,7 +35,11 @@ function Invoke-AzPagedRequest {
             }
 
             if ($response.nextLink){
-                $parsedUri = [System.Uri]::new($response.nextLink)
+                $parsedUri = $null
+                if (-not [System.Uri]::TryCreate($response.nextLink, [System.UriKind]::Absolute, [ref]$parsedUri)) {
+                    Write-Error "Malformed nextLink returned by service. Stopping pagination."
+                    break
+                }
                 # Verify that URI returned is secure and in the list of $allowedHosts
                 if ($parsedUri.Scheme -ne "https" -or $parsedUri.Host -notin $allowedHosts) {
                     throw "Untrusted nextLink host: $($parsedUri.Host). Stopping pagination."

--- a/Private/Invoke-AzPagedRequest.ps1
+++ b/Private/Invoke-AzPagedRequest.ps1
@@ -38,8 +38,7 @@ function Invoke-AzPagedRequest {
                 $parsedUri = [System.Uri]::new($response.nextLink)
                 # Verify that URI returned is secure and in the list of $allowedHosts
                 if ($parsedUri.Scheme -ne "https" -or $parsedUri.Host -notin $allowedHosts) {
-                    Write-Error "Untrusted nextLink host: $($parsedUri.Host). Stopping pagination."
-                    break
+                    throw "Untrusted nextLink host: $($parsedUri.Host). Stopping pagination."
                 }
                 $nextUri = $response.nextLink
             } else {

--- a/Private/Invoke-AzPagedRequest.ps1
+++ b/Private/Invoke-AzPagedRequest.ps1
@@ -33,7 +33,17 @@ function Invoke-AzPagedRequest {
                 $results.AddRange($response.value)
             }
 
-            $nextUri = $response.nextLink
+            if ($response.nextLink){
+                $parsedUri = [System.Uri]::new($response.nextLink)
+                # Verify that URI returned is secure and in the list of $allowedHosts
+                if ($parsedUri.Scheme -ne "https" -or $parsedUri.Host -notin $allowedHosts) {
+                    Write-Error "Untrusted nextLink host: $($parsedUri.Host). Stopping pagination."
+                    break
+                }
+                $nextUri = $response.nextLink
+            } else {
+                $nextUri = $null
+            }
         }
     }
 

--- a/Tests/AzRetirementMonitor.Tests.ps1
+++ b/Tests/AzRetirementMonitor.Tests.ps1
@@ -796,3 +796,78 @@ Describe "Token Audience Validation" {
         $testResult | Should -Be $false
     }
 }
+
+Describe "Invoke-AzPagedRequest NextLink Validation" {
+    BeforeAll {
+        $module = Get-Module AzRetirementMonitor
+    }
+
+    It "Should follow a trusted HTTPS nextLink and return all pages" {
+        $script:mockCallCount = 0
+        $page1 = [PSCustomObject]@{
+            value    = @([PSCustomObject]@{ id = 1 })
+            nextLink = "https://management.azure.com/page2"
+        }
+        $page2 = [PSCustomObject]@{
+            value    = @([PSCustomObject]@{ id = 2 })
+            nextLink = $null
+        }
+        Mock Invoke-RestMethod -ModuleName AzRetirementMonitor {
+            $script:mockCallCount++
+            if ($script:mockCallCount -eq 1) { return $page1 } else { return $page2 }
+        }
+
+        $results = & $module {
+            Invoke-AzPagedRequest -Uri "https://management.azure.com/page1" -Headers @{ Authorization = "Bearer test" }
+        }
+
+        $results.Count | Should -Be 2
+        $results[0].id | Should -Be 1
+        $results[1].id | Should -Be 2
+    }
+
+    It "Should stop pagination and return partial results for HTTP nextLink" {
+        $page1 = [PSCustomObject]@{
+            value    = @([PSCustomObject]@{ id = 1 })
+            nextLink = "http://management.azure.com/page2"
+        }
+        Mock Invoke-RestMethod -ModuleName AzRetirementMonitor { return $page1 }
+
+        $results = & $module {
+            Invoke-AzPagedRequest -Uri "https://management.azure.com/page1" -Headers @{ Authorization = "Bearer test" } -ErrorVariable pagedErrors -ErrorAction SilentlyContinue
+        }
+
+        $results.Count | Should -Be 1
+        $results[0].id | Should -Be 1
+    }
+
+    It "Should stop pagination and return partial results for untrusted host" {
+        $page1 = [PSCustomObject]@{
+            value    = @([PSCustomObject]@{ id = 1 })
+            nextLink = "https://evil.example.com/page2"
+        }
+        Mock Invoke-RestMethod -ModuleName AzRetirementMonitor { return $page1 }
+
+        $results = & $module {
+            Invoke-AzPagedRequest -Uri "https://management.azure.com/page1" -Headers @{ Authorization = "Bearer test" } -ErrorVariable pagedErrors -ErrorAction SilentlyContinue
+        }
+
+        $results.Count | Should -Be 1
+        $results[0].id | Should -Be 1
+    }
+
+    It "Should stop pagination and return partial results for invalid URI" {
+        $page1 = [PSCustomObject]@{
+            value    = @([PSCustomObject]@{ id = 1 })
+            nextLink = "not-a-valid-uri"
+        }
+        Mock Invoke-RestMethod -ModuleName AzRetirementMonitor { return $page1 }
+
+        $results = & $module {
+            Invoke-AzPagedRequest -Uri "https://management.azure.com/page1" -Headers @{ Authorization = "Bearer test" } -ErrorVariable pagedErrors -ErrorAction SilentlyContinue
+        }
+
+        $results.Count | Should -Be 1
+        $results[0].id | Should -Be 1
+    }
+}


### PR DESCRIPTION
## Description

<!-- Provide a clear description of the changes in this PR -->

## Related Issue

Fixes https://github.com/cocallaw/AzRetirementMonitor/issues/24

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [x] Performance improvement
- [ ] Test updates

## Changes Made
This pull request enhances the security of the `Invoke-AzPagedRequest` function by validating the `nextLink` URLs during pagination. The main improvement is to ensure that only trusted hosts over HTTPS are followed, preventing potential security risks from untrusted pagination links.

Security improvements to pagination:

* Added an `$allowedHosts` list (currently allowing only `"management.azure.com"`) to restrict which hosts can be followed in paginated responses.
* Implemented a check to ensure that any `nextLink` URL uses the HTTPS scheme and its host is in the `$allowedHosts` list; if not, an error is logged and pagination stops.
* Updated logic to set `$nextUri` to `$null` when there is no `nextLink`, ensuring proper termination of pagination.

## Testing

<!-- Describe the testing you've performed -->

- [ ] Tested with Azure CLI authentication
- [ ] Tested with Az.Accounts authentication
- [ ] Tested across multiple subscriptions
- [x] Added/updated unit tests
- [ ] All existing tests pass

## Checklist

<!-- Mark completed items with an 'x' -->

- [x] My code follows the existing code style
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation (README, function help, etc.)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally
- [x] I have checked for any breaking changes

## Additional Notes

