### PR TITLE
fix: validate OutputPath to prevent path traversal (#37)

### DIFF
--- a/Public/Export-AzRetirementReport.ps1
+++ b/Public/Export-AzRetirementReport.ps1
@@ -28,6 +28,16 @@ Exports API-sourced recommendations to JSON format
         [object[]]$Recommendations,
 
         [Parameter(Mandatory)]
+        [ValidateScript({
+            if ($_ -match '\.\.[/\\]') {
+                throw "Path traversal sequences are not allowed in OutputPath."
+            }
+            $parent = Split-Path $_ -Parent
+            if ($parent -and -not (Test-Path $parent)) {
+                throw "Directory does not exist: $parent"
+            }
+            $true
+        })]
         [string]$OutputPath,
 
         [ValidateSet("CSV", "JSON", "HTML")]

--- a/Public/Export-AzRetirementReport.ps1
+++ b/Public/Export-AzRetirementReport.ps1
@@ -29,11 +29,12 @@ Exports API-sourced recommendations to JSON format
 
         [Parameter(Mandatory)]
         [ValidateScript({
-            if ($_ -match '\.\.[/\\]') {
+            $pathSegments = ($_ -split '[/\\]' | Where-Object { $_ -ne '' })
+            if ($pathSegments -contains '..') {
                 throw "Path traversal sequences are not allowed in OutputPath."
             }
             $parent = Split-Path $_ -Parent
-            if ($parent -and -not (Test-Path $parent)) {
+            if ($parent -and -not (Test-Path -Path $parent -PathType Container)) {
                 throw "Directory does not exist: $parent"
             }
             $true

--- a/Tests/AzRetirementMonitor.Tests.ps1
+++ b/Tests/AzRetirementMonitor.Tests.ps1
@@ -420,6 +420,17 @@ Describe "Export-AzRetirementReport OutputPath Validation" {
         { $testRec | Export-AzRetirementReport -OutputPath "../../etc/malicious.csv" -Format CSV -Confirm:$false } | Should -Throw "*Path traversal*"
     }
 
+    It "Should reject OutputPath with trailing path traversal" {
+        $testRec = [PSCustomObject]@{
+            SubscriptionId = "sub1"; ResourceId = "id1"; ResourceName = "name1"
+            ResourceType = "type1"; ResourceGroup = "rg1"; Category = "cat1"
+            Impact = "High"; Problem = "p"; Solution = "s"; Description = "d"
+            LastUpdated = "2026-01-01"; IsRetirement = $true
+            RecommendationId = "rec1"; LearnMoreLink = ""; ResourceLink = ""
+        }
+        { $testRec | Export-AzRetirementReport -OutputPath "./foo/../malicious.csv" -Format CSV -Confirm:$false } | Should -Throw "*Path traversal*"
+    }
+
     It "Should reject OutputPath when parent directory does not exist" {
         $testRec = [PSCustomObject]@{
             SubscriptionId = "sub1"; ResourceId = "id1"; ResourceName = "name1"
@@ -428,13 +439,20 @@ Describe "Export-AzRetirementReport OutputPath Validation" {
             LastUpdated = "2026-01-01"; IsRetirement = $true
             RecommendationId = "rec1"; LearnMoreLink = ""; ResourceLink = ""
         }
-        { $testRec | Export-AzRetirementReport -OutputPath "/nonexistent/dir/report.csv" -Format CSV -Confirm:$false } | Should -Throw "*Directory does not exist*"
+        $missingParentDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid().ToString())
+        $missingOutputPath = Join-Path $missingParentDir "report.csv"
+        { $testRec | Export-AzRetirementReport -OutputPath $missingOutputPath -Format CSV -Confirm:$false } | Should -Throw "*Directory does not exist*"
     }
 
     It "Should accept OutputPath in current directory" {
-        $cmd = Get-Command Export-AzRetirementReport
-        $param = $cmd.Parameters['OutputPath']
-        $param | Should -Not -BeNull
+        $testRec = [PSCustomObject]@{
+            SubscriptionId = "sub1"; ResourceId = "id1"; ResourceName = "name1"
+            ResourceType = "type1"; ResourceGroup = "rg1"; Category = "cat1"
+            Impact = "High"; Problem = "p"; Solution = "s"; Description = "d"
+            LastUpdated = "2026-01-01"; IsRetirement = $true
+            RecommendationId = "rec1"; LearnMoreLink = ""; ResourceLink = ""
+        }
+        { $testRec | Export-AzRetirementReport -OutputPath "report.csv" -Format CSV -WhatIf -Confirm:$false } | Should -Not -Throw
     }
 }
 

--- a/Tests/AzRetirementMonitor.Tests.ps1
+++ b/Tests/AzRetirementMonitor.Tests.ps1
@@ -408,6 +408,36 @@ Describe "Export-AzRetirementReport" {
     }
 }
 
+Describe "Export-AzRetirementReport OutputPath Validation" {
+    It "Should reject OutputPath with path traversal sequences" {
+        $testRec = [PSCustomObject]@{
+            SubscriptionId = "sub1"; ResourceId = "id1"; ResourceName = "name1"
+            ResourceType = "type1"; ResourceGroup = "rg1"; Category = "cat1"
+            Impact = "High"; Problem = "p"; Solution = "s"; Description = "d"
+            LastUpdated = "2026-01-01"; IsRetirement = $true
+            RecommendationId = "rec1"; LearnMoreLink = ""; ResourceLink = ""
+        }
+        { $testRec | Export-AzRetirementReport -OutputPath "../../etc/malicious.csv" -Format CSV -Confirm:$false } | Should -Throw "*Path traversal*"
+    }
+
+    It "Should reject OutputPath when parent directory does not exist" {
+        $testRec = [PSCustomObject]@{
+            SubscriptionId = "sub1"; ResourceId = "id1"; ResourceName = "name1"
+            ResourceType = "type1"; ResourceGroup = "rg1"; Category = "cat1"
+            Impact = "High"; Problem = "p"; Solution = "s"; Description = "d"
+            LastUpdated = "2026-01-01"; IsRetirement = $true
+            RecommendationId = "rec1"; LearnMoreLink = ""; ResourceLink = ""
+        }
+        { $testRec | Export-AzRetirementReport -OutputPath "/nonexistent/dir/report.csv" -Format CSV -Confirm:$false } | Should -Throw "*Directory does not exist*"
+    }
+
+    It "Should accept OutputPath in current directory" {
+        $cmd = Get-Command Export-AzRetirementReport
+        $param = $cmd.Parameters['OutputPath']
+        $param | Should -Not -BeNull
+    }
+}
+
 Describe "Export-AzRetirementReport Transformation Logic" {
     BeforeAll {
         # Create a temporary directory for test outputs


### PR DESCRIPTION
## Description
Adds `ValidateScript` to the `OutputPath` parameter in `Export-AzRetirementReport` to prevent path traversal attacks and writing to nonexistent directories.

## Changes
- Rejects paths containing `..` traversal sequences
- Verifies parent directory exists before writing
- Adds unit tests for both validation rules

## Related Issue
Fixes #37

## Testing
- [x] Added unit tests
- [x] All 62 existing + new tests pass