### PR TITLE
fix: add environment protection to publish workflow (#39)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ jobs:
   publish:
     name: Publish Module to PowerShell Gallery
     runs-on: ubuntu-latest
+    environment: production
     permissions:
       contents: read
     


### PR DESCRIPTION
## Description
Adds a `production` environment gate to the publish workflow to prevent unauthorized manual dispatch.

## Changes
- Added `environment: production` to the publish job
- Manual `workflow_dispatch` triggers now require environment approval before executing

## Setup Required
After merging, create a `production` environment in **Settings → Environments** with required reviewers.

## Related Issue
Fixes #39