### PR TITLE
perf: cache ExtendedProperty parse in subcategory filter (#28)

### DIFF
--- a/Private/Resolve-ExtendedProperty.ps1
+++ b/Private/Resolve-ExtendedProperty.ps1
@@ -1,0 +1,45 @@
+function Resolve-ExtendedProperty {
+    <#
+    .SYNOPSIS
+    Parses and caches the ExtendedProperty on a recommendation object.
+
+    .DESCRIPTION
+    Handles ExtendedProperty as a JSON string, hashtable, or PSCustomObject.
+    Returns the parsed object and attaches it as ExtendedPropertyObject on the
+    input object for downstream reuse. Returns $null on parse failure.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [PSObject]$Recommendation
+    )
+
+    if (-not $Recommendation.ExtendedProperty) {
+        return $null
+    }
+
+    # Return cached value if already resolved
+    if ($Recommendation.PSObject.Properties.Name -contains 'ExtendedPropertyObject') {
+        return $Recommendation.ExtendedPropertyObject
+    }
+
+    $extProps = $null
+    try {
+        if ($Recommendation.ExtendedProperty -is [string]) {
+            $extProps = $Recommendation.ExtendedProperty | ConvertFrom-Json
+        }
+        elseif ($Recommendation.ExtendedProperty -is [hashtable] -or $Recommendation.ExtendedProperty -is [pscustomobject]) {
+            $extProps = $Recommendation.ExtendedProperty
+        }
+
+        if ($extProps) {
+            $Recommendation | Add-Member -NotePropertyName ExtendedPropertyObject -NotePropertyValue $extProps -Force
+        }
+    }
+    catch {
+        Write-Verbose "Failed to parse ExtendedProperty: $_"
+        $extProps = $null
+    }
+
+    return $extProps
+}

--- a/Public/Get-AzRetirementRecommendation.ps1
+++ b/Public/Get-AzRetirementRecommendation.ps1
@@ -159,8 +159,14 @@ Gets recommendations using the REST API method
                 # Common filter for ServiceUpgradeAndRetirement subcategory
                 $subcategoryFilter = {
                     if ($_.ExtendedProperty) {
-                        $extProps = $_.ExtendedProperty | ConvertFrom-Json
-                        if ($extProps.recommendationSubCategory -eq 'ServiceUpgradeAndRetirement') {
+                        $extProps = $null
+                        if ($_.ExtendedProperty -is [string]) {
+                            try { $extProps = $_.ExtendedProperty | ConvertFrom-Json } catch { }
+                        }
+                        elseif ($_.ExtendedProperty -is [hashtable] -or $_.ExtendedProperty -is [pscustomobject]) {
+                            $extProps = $_.ExtendedProperty
+                        }
+                        if ($extProps -and $extProps.recommendationSubCategory -eq 'ServiceUpgradeAndRetirement') {
                             $_ | Add-Member -NotePropertyName ExtendedPropertyObject -NotePropertyValue $extProps -Force
                             $true
                         } else { $false }

--- a/Public/Get-AzRetirementRecommendation.ps1
+++ b/Public/Get-AzRetirementRecommendation.ps1
@@ -158,10 +158,12 @@ Gets recommendations using the REST API method
 
                 # Common filter for ServiceUpgradeAndRetirement subcategory
                 $subcategoryFilter = {
-                    # Parse extended properties to check subcategory
                     if ($_.ExtendedProperty) {
                         $extProps = $_.ExtendedProperty | ConvertFrom-Json
-                        $extProps.recommendationSubCategory -eq 'ServiceUpgradeAndRetirement'
+                        if ($extProps.recommendationSubCategory -eq 'ServiceUpgradeAndRetirement') {
+                            $_ | Add-Member -NotePropertyName ExtendedPropertyObject -NotePropertyValue $extProps -Force
+                            $true
+                        } else { $false }
                     }
                     else {
                         $false

--- a/Public/Get-AzRetirementRecommendation.ps1
+++ b/Public/Get-AzRetirementRecommendation.ps1
@@ -161,7 +161,8 @@ Gets recommendations using the REST API method
                     if ($_.ExtendedProperty) {
                         $extProps = $null
                         if ($_.ExtendedProperty -is [string]) {
-                            try { $extProps = $_.ExtendedProperty | ConvertFrom-Json } catch { }
+                            try { $extProps = $_.ExtendedProperty | ConvertFrom-Json }
+                            catch { $extProps = $null }
                         }
                         elseif ($_.ExtendedProperty -is [hashtable] -or $_.ExtendedProperty -is [pscustomobject]) {
                             $extProps = $_.ExtendedProperty

--- a/Public/Get-AzRetirementRecommendation.ps1
+++ b/Public/Get-AzRetirementRecommendation.ps1
@@ -158,23 +158,10 @@ Gets recommendations using the REST API method
 
                 # Common filter for ServiceUpgradeAndRetirement subcategory
                 $subcategoryFilter = {
-                    if ($_.ExtendedProperty) {
-                        $extProps = $null
-                        if ($_.ExtendedProperty -is [string]) {
-                            try { $extProps = $_.ExtendedProperty | ConvertFrom-Json }
-                            catch { $extProps = $null }
-                        }
-                        elseif ($_.ExtendedProperty -is [hashtable] -or $_.ExtendedProperty -is [pscustomobject]) {
-                            $extProps = $_.ExtendedProperty
-                        }
-                        if ($extProps -and $extProps.recommendationSubCategory -eq 'ServiceUpgradeAndRetirement') {
-                            $_ | Add-Member -NotePropertyName ExtendedPropertyObject -NotePropertyValue $extProps -Force
-                            $true
-                        } else { $false }
-                    }
-                    else {
-                        $false
-                    }
+                    $extProps = Resolve-ExtendedProperty -Recommendation $_
+                    if ($extProps -and $extProps.recommendationSubCategory -eq 'ServiceUpgradeAndRetirement') {
+                        $true
+                    } else { $false }
                 }
                 
                 $recommendations = if ($SubscriptionId) {
@@ -233,31 +220,7 @@ Gets recommendations using the REST API method
                     $retirementDate = $null
 
                     if ($rec.ExtendedProperty) {
-                        # Reuse a previously-parsed ExtendedProperty if available to avoid redundant JSON parsing
-                        if ($rec.PSObject.Properties.Name -contains 'ExtendedPropertyObject') {
-                            $extProps = $rec.ExtendedPropertyObject
-                        }
-                        else {
-                            try {
-                                if ($rec.ExtendedProperty -is [string]) {
-                                    # ExtendedProperty is JSON text; parse it once
-                                    $extProps = $rec.ExtendedProperty | ConvertFrom-Json
-                                }
-                                elseif ($rec.ExtendedProperty -is [hashtable] -or $rec.ExtendedProperty -is [pscustomobject]) {
-                                    # ExtendedProperty is already an object; no need to parse
-                                    $extProps = $rec.ExtendedProperty
-                                }
-
-                                if ($extProps) {
-                                    # Cache the parsed object on the recommendation to prevent re-parsing
-                                    $rec | Add-Member -NotePropertyName ExtendedPropertyObject -NotePropertyValue $extProps -Force
-                                }
-                            }
-                            catch {
-                                Write-Verbose "Failed to parse ExtendedProperty: $_"
-                                $extProps = $null
-                            }
-                        }
+                        $extProps = Resolve-ExtendedProperty -Recommendation $rec
 
                         if ($extProps) {
                             $retirementFeatureName = $extProps.retirementFeatureName

--- a/Tests/AzRetirementMonitor.Tests.ps1
+++ b/Tests/AzRetirementMonitor.Tests.ps1
@@ -378,141 +378,84 @@ Describe "Get-AzRetirementRecommendation Subcategory Filter" {
         $functionDef = (Get-Command Get-AzRetirementRecommendation).Definition
     }
 
-    It "Should contain Add-Member caching of ExtendedPropertyObject in the filter" {
-        $functionDef | Should -Match 'Add-Member.*ExtendedPropertyObject'
+    It "Should use Resolve-ExtendedProperty helper in the subcategory filter" {
+        $functionDef | Should -Match 'subcategoryFilter\s*=\s*\{[^}]*Resolve-ExtendedProperty'
     }
 
-    It "Should contain type checks for string, hashtable, and pscustomobject" {
-        $functionDef | Should -Match 'ExtendedProperty -is \[string\]'
-        $functionDef | Should -Match 'ExtendedProperty -is \[hashtable\]'
-        $functionDef | Should -Match 'ExtendedProperty -is \[pscustomobject\]'
+    It "Should use Resolve-ExtendedProperty helper in the output construction" {
+        # Verify the helper is also used outside the filter (in the foreach loop)
+        $functionDef | Should -Match 'Resolve-ExtendedProperty -Recommendation \$rec'
+    }
+}
+
+Describe "Resolve-ExtendedProperty" {
+    It "Should parse JSON string and cache as ExtendedPropertyObject" {
+        InModuleScope AzRetirementMonitor {
+            $rec = [PSCustomObject]@{
+                ExtendedProperty = '{"recommendationSubCategory":"ServiceUpgradeAndRetirement","retirementFeatureName":"Test"}'
+            }
+            $result = Resolve-ExtendedProperty -Recommendation $rec
+            $result | Should -Not -BeNullOrEmpty
+            $result.retirementFeatureName | Should -Be 'Test'
+            $rec.PSObject.Properties.Name | Should -Contain 'ExtendedPropertyObject'
+            $rec.ExtendedPropertyObject.retirementFeatureName | Should -Be 'Test'
+        }
     }
 
-    It "Should handle ExtendedProperty as JSON string and cache parsed object" {
-        # Use a mock that returns a recommendation with JSON string ExtendedProperty
-        $mockRec = [PSCustomObject]@{
-            Name = 'test-rec'
-            ExtendedProperty = '{"recommendationSubCategory":"ServiceUpgradeAndRetirement","retirementFeatureName":"Test"}'
+    It "Should handle hashtable input" {
+        InModuleScope AzRetirementMonitor {
+            $rec = [PSCustomObject]@{
+                ExtendedProperty = @{ recommendationSubCategory = 'ServiceUpgradeAndRetirement'; retirementFeatureName = 'HashTest' }
+            }
+            $result = Resolve-ExtendedProperty -Recommendation $rec
+            $result | Should -Not -BeNullOrEmpty
+            $result.retirementFeatureName | Should -Be 'HashTest'
+            $rec.PSObject.Properties.Name | Should -Contain 'ExtendedPropertyObject'
         }
-        Mock Get-AzAdvisorRecommendation { return $mockRec } -ModuleName AzRetirementMonitor
-
-        # Invoke the filter logic as defined in the function
-        $result = @($mockRec) | Where-Object {
-            if ($_.ExtendedProperty) {
-                $extProps = $null
-                if ($_.ExtendedProperty -is [string]) {
-                    try { $extProps = $_.ExtendedProperty | ConvertFrom-Json }
-                    catch { $extProps = $null }
-                }
-                elseif ($_.ExtendedProperty -is [hashtable] -or $_.ExtendedProperty -is [pscustomobject]) {
-                    $extProps = $_.ExtendedProperty
-                }
-                if ($extProps -and $extProps.recommendationSubCategory -eq 'ServiceUpgradeAndRetirement') {
-                    $_ | Add-Member -NotePropertyName ExtendedPropertyObject -NotePropertyValue $extProps -Force
-                    $true
-                } else { $false }
-            } else { $false }
-        }
-        $result | Should -HaveCount 1
-        $result[0].PSObject.Properties.Name | Should -Contain 'ExtendedPropertyObject'
-        $result[0].ExtendedPropertyObject.retirementFeatureName | Should -Be 'Test'
     }
 
-    It "Should handle ExtendedProperty as hashtable" {
-        $mockRec = [PSCustomObject]@{
-            Name = 'test-rec'
-            ExtendedProperty = @{ recommendationSubCategory = 'ServiceUpgradeAndRetirement'; retirementFeatureName = 'HashTest' }
+    It "Should handle PSCustomObject input" {
+        InModuleScope AzRetirementMonitor {
+            $rec = [PSCustomObject]@{
+                ExtendedProperty = [PSCustomObject]@{ recommendationSubCategory = 'ServiceUpgradeAndRetirement'; retirementFeatureName = 'ObjTest' }
+            }
+            $result = Resolve-ExtendedProperty -Recommendation $rec
+            $result | Should -Not -BeNullOrEmpty
+            $result.retirementFeatureName | Should -Be 'ObjTest'
         }
-        $result = @($mockRec) | Where-Object {
-            if ($_.ExtendedProperty) {
-                $extProps = $null
-                if ($_.ExtendedProperty -is [string]) {
-                    try { $extProps = $_.ExtendedProperty | ConvertFrom-Json }
-                    catch { $extProps = $null }
-                }
-                elseif ($_.ExtendedProperty -is [hashtable] -or $_.ExtendedProperty -is [pscustomobject]) {
-                    $extProps = $_.ExtendedProperty
-                }
-                if ($extProps -and $extProps.recommendationSubCategory -eq 'ServiceUpgradeAndRetirement') {
-                    $_ | Add-Member -NotePropertyName ExtendedPropertyObject -NotePropertyValue $extProps -Force
-                    $true
-                } else { $false }
-            } else { $false }
-        }
-        $result | Should -HaveCount 1
-        $result[0].ExtendedPropertyObject.retirementFeatureName | Should -Be 'HashTest'
     }
 
-    It "Should filter out non-matching subcategory" {
-        $mockRec = [PSCustomObject]@{
-            Name = 'test-rec'
-            ExtendedProperty = '{"recommendationSubCategory":"SomeOtherCategory"}'
+    It "Should return cached value on second call" {
+        InModuleScope AzRetirementMonitor {
+            $rec = [PSCustomObject]@{
+                ExtendedProperty = '{"recommendationSubCategory":"ServiceUpgradeAndRetirement","retirementFeatureName":"Cached"}'
+            }
+            $first = Resolve-ExtendedProperty -Recommendation $rec
+            $second = Resolve-ExtendedProperty -Recommendation $rec
+            $second.retirementFeatureName | Should -Be 'Cached'
+            [object]::ReferenceEquals($first, $second) | Should -BeTrue
         }
-        $result = @($mockRec) | Where-Object {
-            if ($_.ExtendedProperty) {
-                $extProps = $null
-                if ($_.ExtendedProperty -is [string]) {
-                    try { $extProps = $_.ExtendedProperty | ConvertFrom-Json }
-                    catch { $extProps = $null }
-                }
-                elseif ($_.ExtendedProperty -is [hashtable] -or $_.ExtendedProperty -is [pscustomobject]) {
-                    $extProps = $_.ExtendedProperty
-                }
-                if ($extProps -and $extProps.recommendationSubCategory -eq 'ServiceUpgradeAndRetirement') {
-                    $_ | Add-Member -NotePropertyName ExtendedPropertyObject -NotePropertyValue $extProps -Force
-                    $true
-                } else { $false }
-            } else { $false }
-        }
-        $result | Should -HaveCount 0
     }
 
-    It "Should gracefully handle invalid JSON without throwing" {
-        $mockRec = [PSCustomObject]@{
-            Name = 'test-rec'
-            ExtendedProperty = 'not-valid-json{{'
+    It "Should return null for invalid JSON without throwing" {
+        InModuleScope AzRetirementMonitor {
+            $rec = [PSCustomObject]@{
+                ExtendedProperty = 'not-valid-json{{'
+            }
+            { Resolve-ExtendedProperty -Recommendation $rec } | Should -Not -Throw
+            $result = Resolve-ExtendedProperty -Recommendation $rec
+            $result | Should -BeNullOrEmpty
         }
-        $result = @($mockRec) | Where-Object {
-            if ($_.ExtendedProperty) {
-                $extProps = $null
-                if ($_.ExtendedProperty -is [string]) {
-                    try { $extProps = $_.ExtendedProperty | ConvertFrom-Json }
-                    catch { $extProps = $null }
-                }
-                elseif ($_.ExtendedProperty -is [hashtable] -or $_.ExtendedProperty -is [pscustomobject]) {
-                    $extProps = $_.ExtendedProperty
-                }
-                if ($extProps -and $extProps.recommendationSubCategory -eq 'ServiceUpgradeAndRetirement') {
-                    $_ | Add-Member -NotePropertyName ExtendedPropertyObject -NotePropertyValue $extProps -Force
-                    $true
-                } else { $false }
-            } else { $false }
-        }
-        $result | Should -HaveCount 0
     }
 
-    It "Should filter out items with null ExtendedProperty" {
-        $mockRec = [PSCustomObject]@{
-            Name = 'test-rec'
-            ExtendedProperty = $null
+    It "Should return null for null ExtendedProperty" {
+        InModuleScope AzRetirementMonitor {
+            $rec = [PSCustomObject]@{
+                ExtendedProperty = $null
+            }
+            $result = Resolve-ExtendedProperty -Recommendation $rec
+            $result | Should -BeNullOrEmpty
         }
-        $result = @($mockRec) | Where-Object {
-            if ($_.ExtendedProperty) {
-                $extProps = $null
-                if ($_.ExtendedProperty -is [string]) {
-                    try { $extProps = $_.ExtendedProperty | ConvertFrom-Json }
-                    catch { $extProps = $null }
-                }
-                elseif ($_.ExtendedProperty -is [hashtable] -or $_.ExtendedProperty -is [pscustomobject]) {
-                    $extProps = $_.ExtendedProperty
-                }
-                if ($extProps -and $extProps.recommendationSubCategory -eq 'ServiceUpgradeAndRetirement') {
-                    $_ | Add-Member -NotePropertyName ExtendedPropertyObject -NotePropertyValue $extProps -Force
-                    $true
-                } else { $false }
-            } else { $false }
-        }
-        $result | Should -HaveCount 0
     }
 }
 

--- a/Tests/AzRetirementMonitor.Tests.ps1
+++ b/Tests/AzRetirementMonitor.Tests.ps1
@@ -373,6 +373,126 @@ Describe "Get-AzRetirementRecommendation Context Switching Logic" {
     }
 }
 
+Describe "Get-AzRetirementRecommendation Subcategory Filter" {
+    BeforeAll {
+        # Extract the subcategory filter scriptblock from the function definition
+        $functionDef = (Get-Command Get-AzRetirementRecommendation).Definition
+    }
+
+    It "Should handle ExtendedProperty as JSON string and cache parsed object" {
+        $rec = [PSCustomObject]@{
+            ExtendedProperty = '{"recommendationSubCategory":"ServiceUpgradeAndRetirement","retirementFeatureName":"Test"}'
+        }
+        $result = @($rec) | Where-Object {
+            if ($_.ExtendedProperty) {
+                $extProps = $null
+                if ($_.ExtendedProperty -is [string]) {
+                    try { $extProps = $_.ExtendedProperty | ConvertFrom-Json } catch { }
+                }
+                elseif ($_.ExtendedProperty -is [hashtable] -or $_.ExtendedProperty -is [pscustomobject]) {
+                    $extProps = $_.ExtendedProperty
+                }
+                if ($extProps -and $extProps.recommendationSubCategory -eq 'ServiceUpgradeAndRetirement') {
+                    $_ | Add-Member -NotePropertyName ExtendedPropertyObject -NotePropertyValue $extProps -Force
+                    $true
+                } else { $false }
+            } else { $false }
+        }
+        $result | Should -HaveCount 1
+        $result[0].PSObject.Properties.Name | Should -Contain 'ExtendedPropertyObject'
+        $result[0].ExtendedPropertyObject.retirementFeatureName | Should -Be 'Test'
+    }
+
+    It "Should handle ExtendedProperty as hashtable" {
+        $rec = [PSCustomObject]@{
+            ExtendedProperty = @{ recommendationSubCategory = 'ServiceUpgradeAndRetirement'; retirementFeatureName = 'HashTest' }
+        }
+        $result = @($rec) | Where-Object {
+            if ($_.ExtendedProperty) {
+                $extProps = $null
+                if ($_.ExtendedProperty -is [string]) {
+                    try { $extProps = $_.ExtendedProperty | ConvertFrom-Json } catch { }
+                }
+                elseif ($_.ExtendedProperty -is [hashtable] -or $_.ExtendedProperty -is [pscustomobject]) {
+                    $extProps = $_.ExtendedProperty
+                }
+                if ($extProps -and $extProps.recommendationSubCategory -eq 'ServiceUpgradeAndRetirement') {
+                    $_ | Add-Member -NotePropertyName ExtendedPropertyObject -NotePropertyValue $extProps -Force
+                    $true
+                } else { $false }
+            } else { $false }
+        }
+        $result | Should -HaveCount 1
+        $result[0].ExtendedPropertyObject.retirementFeatureName | Should -Be 'HashTest'
+    }
+
+    It "Should filter out non-matching subcategory" {
+        $rec = [PSCustomObject]@{
+            ExtendedProperty = '{"recommendationSubCategory":"SomeOtherCategory"}'
+        }
+        $result = @($rec) | Where-Object {
+            if ($_.ExtendedProperty) {
+                $extProps = $null
+                if ($_.ExtendedProperty -is [string]) {
+                    try { $extProps = $_.ExtendedProperty | ConvertFrom-Json } catch { }
+                }
+                elseif ($_.ExtendedProperty -is [hashtable] -or $_.ExtendedProperty -is [pscustomobject]) {
+                    $extProps = $_.ExtendedProperty
+                }
+                if ($extProps -and $extProps.recommendationSubCategory -eq 'ServiceUpgradeAndRetirement') {
+                    $_ | Add-Member -NotePropertyName ExtendedPropertyObject -NotePropertyValue $extProps -Force
+                    $true
+                } else { $false }
+            } else { $false }
+        }
+        $result | Should -HaveCount 0
+    }
+
+    It "Should gracefully handle invalid JSON without throwing" {
+        $rec = [PSCustomObject]@{
+            ExtendedProperty = 'not-valid-json{{'
+        }
+        $result = @($rec) | Where-Object {
+            if ($_.ExtendedProperty) {
+                $extProps = $null
+                if ($_.ExtendedProperty -is [string]) {
+                    try { $extProps = $_.ExtendedProperty | ConvertFrom-Json } catch { }
+                }
+                elseif ($_.ExtendedProperty -is [hashtable] -or $_.ExtendedProperty -is [pscustomobject]) {
+                    $extProps = $_.ExtendedProperty
+                }
+                if ($extProps -and $extProps.recommendationSubCategory -eq 'ServiceUpgradeAndRetirement') {
+                    $_ | Add-Member -NotePropertyName ExtendedPropertyObject -NotePropertyValue $extProps -Force
+                    $true
+                } else { $false }
+            } else { $false }
+        }
+        $result | Should -HaveCount 0
+    }
+
+    It "Should filter out items with null ExtendedProperty" {
+        $rec = [PSCustomObject]@{
+            ExtendedProperty = $null
+        }
+        $result = @($rec) | Where-Object {
+            if ($_.ExtendedProperty) {
+                $extProps = $null
+                if ($_.ExtendedProperty -is [string]) {
+                    try { $extProps = $_.ExtendedProperty | ConvertFrom-Json } catch { }
+                }
+                elseif ($_.ExtendedProperty -is [hashtable] -or $_.ExtendedProperty -is [pscustomobject]) {
+                    $extProps = $_.ExtendedProperty
+                }
+                if ($extProps -and $extProps.recommendationSubCategory -eq 'ServiceUpgradeAndRetirement') {
+                    $_ | Add-Member -NotePropertyName ExtendedPropertyObject -NotePropertyValue $extProps -Force
+                    $true
+                } else { $false }
+            } else { $false }
+        }
+        $result | Should -HaveCount 0
+    }
+}
+
 Describe "Get-AzRetirementMetadataItem" {
     It "Should have no parameters" {
         $cmd = Get-Command Get-AzRetirementMetadataItem

--- a/Tests/AzRetirementMonitor.Tests.ps1
+++ b/Tests/AzRetirementMonitor.Tests.ps1
@@ -375,19 +375,34 @@ Describe "Get-AzRetirementRecommendation Context Switching Logic" {
 
 Describe "Get-AzRetirementRecommendation Subcategory Filter" {
     BeforeAll {
-        # Extract the subcategory filter scriptblock from the function definition
         $functionDef = (Get-Command Get-AzRetirementRecommendation).Definition
     }
 
+    It "Should contain Add-Member caching of ExtendedPropertyObject in the filter" {
+        $functionDef | Should -Match 'Add-Member.*ExtendedPropertyObject'
+    }
+
+    It "Should contain type checks for string, hashtable, and pscustomobject" {
+        $functionDef | Should -Match 'ExtendedProperty -is \[string\]'
+        $functionDef | Should -Match 'ExtendedProperty -is \[hashtable\]'
+        $functionDef | Should -Match 'ExtendedProperty -is \[pscustomobject\]'
+    }
+
     It "Should handle ExtendedProperty as JSON string and cache parsed object" {
-        $rec = [PSCustomObject]@{
+        # Use a mock that returns a recommendation with JSON string ExtendedProperty
+        $mockRec = [PSCustomObject]@{
+            Name = 'test-rec'
             ExtendedProperty = '{"recommendationSubCategory":"ServiceUpgradeAndRetirement","retirementFeatureName":"Test"}'
         }
-        $result = @($rec) | Where-Object {
+        Mock Get-AzAdvisorRecommendation { return $mockRec } -ModuleName AzRetirementMonitor
+
+        # Invoke the filter logic as defined in the function
+        $result = @($mockRec) | Where-Object {
             if ($_.ExtendedProperty) {
                 $extProps = $null
                 if ($_.ExtendedProperty -is [string]) {
-                    try { $extProps = $_.ExtendedProperty | ConvertFrom-Json } catch { }
+                    try { $extProps = $_.ExtendedProperty | ConvertFrom-Json }
+                    catch { $extProps = $null }
                 }
                 elseif ($_.ExtendedProperty -is [hashtable] -or $_.ExtendedProperty -is [pscustomobject]) {
                     $extProps = $_.ExtendedProperty
@@ -404,14 +419,16 @@ Describe "Get-AzRetirementRecommendation Subcategory Filter" {
     }
 
     It "Should handle ExtendedProperty as hashtable" {
-        $rec = [PSCustomObject]@{
+        $mockRec = [PSCustomObject]@{
+            Name = 'test-rec'
             ExtendedProperty = @{ recommendationSubCategory = 'ServiceUpgradeAndRetirement'; retirementFeatureName = 'HashTest' }
         }
-        $result = @($rec) | Where-Object {
+        $result = @($mockRec) | Where-Object {
             if ($_.ExtendedProperty) {
                 $extProps = $null
                 if ($_.ExtendedProperty -is [string]) {
-                    try { $extProps = $_.ExtendedProperty | ConvertFrom-Json } catch { }
+                    try { $extProps = $_.ExtendedProperty | ConvertFrom-Json }
+                    catch { $extProps = $null }
                 }
                 elseif ($_.ExtendedProperty -is [hashtable] -or $_.ExtendedProperty -is [pscustomobject]) {
                     $extProps = $_.ExtendedProperty
@@ -427,14 +444,16 @@ Describe "Get-AzRetirementRecommendation Subcategory Filter" {
     }
 
     It "Should filter out non-matching subcategory" {
-        $rec = [PSCustomObject]@{
+        $mockRec = [PSCustomObject]@{
+            Name = 'test-rec'
             ExtendedProperty = '{"recommendationSubCategory":"SomeOtherCategory"}'
         }
-        $result = @($rec) | Where-Object {
+        $result = @($mockRec) | Where-Object {
             if ($_.ExtendedProperty) {
                 $extProps = $null
                 if ($_.ExtendedProperty -is [string]) {
-                    try { $extProps = $_.ExtendedProperty | ConvertFrom-Json } catch { }
+                    try { $extProps = $_.ExtendedProperty | ConvertFrom-Json }
+                    catch { $extProps = $null }
                 }
                 elseif ($_.ExtendedProperty -is [hashtable] -or $_.ExtendedProperty -is [pscustomobject]) {
                     $extProps = $_.ExtendedProperty
@@ -449,14 +468,16 @@ Describe "Get-AzRetirementRecommendation Subcategory Filter" {
     }
 
     It "Should gracefully handle invalid JSON without throwing" {
-        $rec = [PSCustomObject]@{
+        $mockRec = [PSCustomObject]@{
+            Name = 'test-rec'
             ExtendedProperty = 'not-valid-json{{'
         }
-        $result = @($rec) | Where-Object {
+        $result = @($mockRec) | Where-Object {
             if ($_.ExtendedProperty) {
                 $extProps = $null
                 if ($_.ExtendedProperty -is [string]) {
-                    try { $extProps = $_.ExtendedProperty | ConvertFrom-Json } catch { }
+                    try { $extProps = $_.ExtendedProperty | ConvertFrom-Json }
+                    catch { $extProps = $null }
                 }
                 elseif ($_.ExtendedProperty -is [hashtable] -or $_.ExtendedProperty -is [pscustomobject]) {
                     $extProps = $_.ExtendedProperty
@@ -471,14 +492,16 @@ Describe "Get-AzRetirementRecommendation Subcategory Filter" {
     }
 
     It "Should filter out items with null ExtendedProperty" {
-        $rec = [PSCustomObject]@{
+        $mockRec = [PSCustomObject]@{
+            Name = 'test-rec'
             ExtendedProperty = $null
         }
-        $result = @($rec) | Where-Object {
+        $result = @($mockRec) | Where-Object {
             if ($_.ExtendedProperty) {
                 $extProps = $null
                 if ($_.ExtendedProperty -is [string]) {
-                    try { $extProps = $_.ExtendedProperty | ConvertFrom-Json } catch { }
+                    try { $extProps = $_.ExtendedProperty | ConvertFrom-Json }
+                    catch { $extProps = $null }
                 }
                 elseif ($_.ExtendedProperty -is [hashtable] -or $_.ExtendedProperty -is [pscustomobject]) {
                     $extProps = $_.ExtendedProperty


### PR DESCRIPTION
## Description
Eliminates redundant `ConvertFrom-Json` call by caching the parsed `ExtendedProperty` during the subcategory filter step.

## Changes
- Parse JSON once in the `Where-Object` filter and attach result as `ExtendedPropertyObject` via `Add-Member`
- Downstream code already checks for `ExtendedPropertyObject` before re-parsing, so this completes the optimization

## Related Issue
Fixes #28