### PR TITLE
perf: replace array concatenation with List[object] in Export-AzRetirementReport (#29)

### DIFF
--- a/Public/Export-AzRetirementReport.ps1
+++ b/Public/Export-AzRetirementReport.ps1
@@ -35,11 +35,13 @@ Exports API-sourced recommendations to JSON format
     )
 
     begin {
-        $allRecs = @()
+        $allRecs = [System.Collections.Generic.List[object]]::new()
     }
 
     process {
-        $allRecs += $Recommendations
+        foreach ($rec in $Recommendations) {
+            $allRecs.Add($rec)
+        }
     }
 
     end {


### PR DESCRIPTION
## Description
Replaces O(n²) array concatenation with O(1) amortized `List[object].Add()` in the pipeline `process` block.

## Changes
- `begin`: Initialize `[System.Collections.Generic.List[object]]` instead of `@()`
- `process`: Use `foreach`/`.Add()` instead of `+=`

## Related Issue
Fixes #29