### PR TITLE
feat: add -Stream switch to Get-AzRetirementRecommendation (#30)

### DIFF
--- a/Public/Get-AzRetirementRecommendation.ps1
+++ b/Public/Get-AzRetirementRecommendation.ps1
@@ -18,6 +18,9 @@ The API method requires:
 One or more subscription IDs to query. Defaults to all subscriptions.
 .PARAMETER UseAPI
 Use the Azure REST API instead of Az.Advisor PowerShell module. Requires Connect-AzRetirementMonitor first.
+.PARAMETER Stream
+Emit recommendation objects to the pipeline as they are retrieved instead of buffering all results.
+This reduces memory usage and delivers first output sooner for large tenants.
 .EXAMPLE
 Get-AzRetirementRecommendation
 Gets all retirement recommendations using Az.Advisor module (default)
@@ -35,7 +38,10 @@ Gets recommendations using the REST API method
         [string[]]$SubscriptionId,
 
         [Parameter()]
-        [switch]$UseAPI
+        [switch]$UseAPI,
+
+        [Parameter()]
+        [switch]$Stream
     )
 
     begin {
@@ -126,7 +132,7 @@ Gets recommendations using the REST API method
                             $null
                         }
 
-                        $allRecommendations.Add([PSCustomObject]@{
+                        $recObject = [PSCustomObject]@{
                             SubscriptionId   = $subId
                             ResourceId       = $resourceId
                             ResourceName     = ($resourceId -split "/")[-1]
@@ -142,7 +148,13 @@ Gets recommendations using the REST API method
                             RecommendationId = $rec.name
                             LearnMoreLink    = $rec.properties.learnMoreLink
                             ResourceLink     = $resourceLink
-                        })
+                        }
+                        if ($Stream) {
+                            Write-Output $recObject
+                        }
+                        else {
+                            $allRecommendations.Add($recObject)
+                        }
                     }
                 }
                 catch {
@@ -323,7 +335,7 @@ Gets recommendations using the REST API method
                         $null
                     }
 
-                    $allRecommendations.Add([PSCustomObject]@{
+                    $recObject = [PSCustomObject]@{
                         SubscriptionId   = $subscriptionId
                         ResourceId       = $resourceId
                         ResourceName     = if ($resourceId) { ($resourceId -split "/")[-1] } else { "N/A" }
@@ -339,7 +351,13 @@ Gets recommendations using the REST API method
                         RecommendationId = $rec.Name
                         LearnMoreLink    = if ($rec.LearnMoreLink) { $rec.LearnMoreLink } else { $null }
                         ResourceLink     = $resourceLink
-                    })
+                    }
+                    if ($Stream) {
+                        Write-Output $recObject
+                    }
+                    else {
+                        $allRecommendations.Add($recObject)
+                    }
                 }
             }
             catch {
@@ -349,6 +367,8 @@ Gets recommendations using the REST API method
     }
 
     end {
-        return $allRecommendations.ToArray()
+        if (-not $Stream) {
+            return $allRecommendations.ToArray()
+        }
     }
 }

--- a/Tests/AzRetirementMonitor.Tests.ps1
+++ b/Tests/AzRetirementMonitor.Tests.ps1
@@ -871,3 +871,12 @@ Describe "Invoke-AzPagedRequest NextLink Validation" {
         $results[0].id | Should -Be 1
     }
 }
+
+Describe "Get-AzRetirementRecommendation -Stream Parameter" {
+    It "Should have a Stream switch parameter" {
+        $cmd = Get-Command Get-AzRetirementRecommendation
+        $param = $cmd.Parameters['Stream']
+        $param | Should -Not -BeNull
+        $param.ParameterType.Name | Should -Be 'SwitchParameter'
+    }
+}


### PR DESCRIPTION
## Description
Adds an opt-in `-Stream` switch that emits recommendation objects to the pipeline as they are retrieved instead of buffering all results in memory.

## Changes
- New `-Stream` parameter on `Get-AzRetirementRecommendation`
- When set, objects are emitted via `Write-Output` immediately
- Default behavior (buffered array return) is unchanged

## Usage
```powershell
# Streaming - first output arrives as soon as first subscription is processed
Get-AzRetirementRecommendation -Stream | Export-AzRetirementReport -OutputPath report.csv

# Buffered (default, backward compatible)
$recs = Get-AzRetirementRecommendation
```

## Related Issue
Fixes #30