### PR TITLE
docs: add missing help sections to Get-AzRetirementMetadataItem (#43)

### DIFF
--- a/Public/Get-AzRetirementMetadataItem.ps1
+++ b/Public/Get-AzRetirementMetadataItem.ps1
@@ -5,6 +5,13 @@ Gets Azure Advisor recommendation metadata
 .DESCRIPTION
 Note: This function only works with the -UseAPI mode as Az.Advisor module does not 
 expose metadata retrieval cmdlets. You must run Connect-AzRetirementMonitor -UsingAPI first.
+.EXAMPLE
+Get-AzRetirementMetadataItem
+Gets all retirement-related metadata items from Azure Advisor.
+.OUTPUTS
+PSCustomObject
+.LINK
+https://learn.microsoft.com/rest/api/advisor/metadata
 #>
     [CmdletBinding()]
     param()


### PR DESCRIPTION
## Description
Adds `.EXAMPLE`, `.OUTPUTS`, and `.LINK` sections to the comment-based help for `Get-AzRetirementMetadataItem`, matching the pattern used by all other public functions.

## Related Issue
Fixes #43