### PR TITLE
fix: protect API access token storage

### DIFF
--- a/AzRetirementMonitor.psm1
+++ b/AzRetirementMonitor.psm1
@@ -1,12 +1,6 @@
-# Module-scoped access token storage
-# Security Note: The access token is stored in plain text in memory as a module-scoped variable.
-# This is acceptable because:
-# 1. These are short-lived session tokens (typically 1 hour), not long-lived credentials
-# 2. The token is only accessible within this module's scope, not from other modules
-# 3. The token is cleared when the module is unloaded or via Disconnect-AzRetirementMonitor
-# 4. PowerShell doesn't provide secure string protection for in-memory session tokens
-# 5. The token expires automatically based on Azure's token lifetime policies
-$script:AccessToken = $null
+# Store the token encrypted at rest in the module scope. Plaintext is created only
+# transiently while building an HTTP Authorization header.
+$script:AccessTokenSecureString = $null
 $script:ApiVersion  = "2025-01-01"
 
 $Public  = Get-ChildItem "$PSScriptRoot/Public/*.ps1" -Recurse

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - NextLink origin validation in `Invoke-AzPagedRequest` to prevent token forwarding to untrusted hosts (#24)
 
 ### Changed
+- API access tokens are retained as `SecureString` values instead of plaintext module-scoped strings; plaintext is created only while preparing REST request headers (#25)
 - `Export-AzRetirementReport` uses `List[object]` instead of array concatenation for O(1) appends (#29)
 - ExtendedProperty JSON is now parsed once and cached during subcategory filtering (#28)
 - README and help text accurately describe token clearing behavior (#25, #41)

--- a/Private/Invoke-AzPagedRequest.ps1
+++ b/Private/Invoke-AzPagedRequest.ps1
@@ -11,6 +11,11 @@ function Invoke-AzPagedRequest {
         [int]$PageLimit = 100
     )
 
+    if ($script:AccessTokenSecureString) {
+        $credential = New-Object System.Management.Automation.PSCredential("token", $script:AccessTokenSecureString)
+        $Headers.Authorization = "Bearer $($credential.GetNetworkCredential().Password)"
+    }
+
     $results = [System.Collections.Generic.List[object]]::new()
     $allowedHosts = @("management.azure.com")
     $nextUri = $Uri

--- a/Private/Test-AzRetirementMonitorToken.ps1
+++ b/Private/Test-AzRetirementMonitorToken.ps1
@@ -22,13 +22,19 @@ function Test-AzRetirementMonitorToken {
     [OutputType([bool])]
     param()
 
-    if (-not $script:AccessToken) {
+    if (-not $script:AccessTokenSecureString) {
         return $false
     }
 
     try {
+        $credential = New-Object System.Management.Automation.PSCredential(
+            "token",
+            $script:AccessTokenSecureString
+        )
+        $accessToken = $credential.GetNetworkCredential().Password
+
         # JWT tokens have 3 parts separated by dots: header.payload.signature
-        $tokenParts = $script:AccessToken -split '\.'
+        $tokenParts = $accessToken -split '\.'
         
         if ($tokenParts.Count -ne 3) {
             Write-Verbose "Token format is invalid"

--- a/Public/Connect-AzRetirementMonitor.ps1
+++ b/Public/Connect-AzRetirementMonitor.ps1
@@ -1,7 +1,7 @@
 function Connect-AzRetirementMonitor {
 <#
 .SYNOPSIS
-Authenticates to Azure and stores an access token for REST API access
+Authenticates to Azure and securely stores an access token for REST API access
 .DESCRIPTION
 ⚠️  IMPORTANT: This command is ONLY needed when using Get-AzRetirementRecommendation with the -UseAPI switch.
 
@@ -20,10 +20,10 @@ The token obtained is used exclusively for:
 
 Required RBAC permissions: Reader role at subscription or resource group scope
 
-The token is stored in a module-scoped variable for the duration of the PowerShell session
-and is validated for proper audience (https://management.azure.com) before use.
-Note: Module scope is not a security boundary — avoid running untrusted scripts in the same session.
-Run Disconnect-AzRetirementMonitor when finished to clear the token reference.
+The token is stored as a SecureString in module scope for the duration of the PowerShell
+session and is validated for proper audience (https://management.azure.com) before use.
+Plaintext is created only transiently while an API request is prepared. Run
+Disconnect-AzRetirementMonitor when finished to clear the token reference.
 .PARAMETER UsingAPI
 Required switch to confirm you intend to use API-based access. This prevents accidentally 
 connecting when using the default Az.Advisor module method.
@@ -58,7 +58,7 @@ None. Displays a success message when authentication completes.
 
     try {
         # Clear any previously stored token so a failure never leaves a stale token in scope
-        $script:AccessToken = $null
+        $script:AccessTokenSecureString = $null
 
         if ($UseAzPowerShell) {
             if (-not (Get-Module -ListAvailable -Name Az.Accounts)) {
@@ -74,21 +74,20 @@ None. Displays a success message when authentication completes.
             Write-Verbose "Requesting token scoped to https://management.azure.com for read-only Azure Advisor access"
             $token = Get-AzAccessToken -ResourceUrl "https://management.azure.com"
             
-            # Starting with Az.Accounts 5.0.0, the Token property is a SecureString
-            # We need to convert it to plain text for use in Authorization headers
-            # This conversion is necessary because REST API calls require the token as a string
-            if ($token.Token -is [System.Security.SecureString]) {
-                # Use PSCredential to convert SecureString to plain text
-                $credential = New-Object System.Management.Automation.PSCredential("token", $token.Token)
-                $script:AccessToken = $credential.GetNetworkCredential().Password
+            # Keep the token encrypted in module scope; REST headers are assembled per request.
+            if (-not $token.Token) {
+                $script:AccessTokenSecureString = $null
+            }
+            elseif ($token.Token -is [System.Security.SecureString]) {
+                $script:AccessTokenSecureString = $token.Token
             }
             else {
-                # Backwards compatibility for older Az.Accounts versions that return plain text
-                $script:AccessToken = $token.Token
+                # Backwards compatibility for older Az.Accounts versions that return plain text.
+                $script:AccessTokenSecureString = ConvertTo-SecureString -String $token.Token -AsPlainText -Force
             }
 
-            if ([string]::IsNullOrWhiteSpace($script:AccessToken)) {
-                $script:AccessToken = $null
+            if (-not $script:AccessTokenSecureString) {
+                $script:AccessTokenSecureString = $null
                 throw "Failed to acquire access token from Az.Accounts. Ensure you are connected with 'Connect-AzAccount'."
             }
         }
@@ -99,15 +98,17 @@ None. Displays a success message when authentication completes.
             }
             Write-Verbose "Using Azure CLI for authentication"
             Write-Verbose "Requesting token scoped to https://management.azure.com for read-only Azure Advisor access"
-            $script:AccessToken = & az account get-access-token `
+            $plainTextToken = & az account get-access-token `
                 --resource https://management.azure.com `
                 --query accessToken `
                 --output tsv
 
-            if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($script:AccessToken)) {
-                $script:AccessToken = $null
+            if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($plainTextToken)) {
+                $script:AccessTokenSecureString = $null
                 throw "Failed to acquire access token from Azure CLI. Ensure you are logged in with 'az login' and have access to the target subscription."
             }
+            $script:AccessTokenSecureString = ConvertTo-SecureString -String ($plainTextToken.Trim()) -AsPlainText -Force
+            $plainTextToken = $null
         }
 
         Write-Host "Authenticated to Azure successfully for API access"

--- a/Public/Disconnect-AzRetirementMonitor.ps1
+++ b/Public/Disconnect-AzRetirementMonitor.ps1
@@ -6,9 +6,9 @@ Disconnects from AzRetirementMonitor by clearing the stored access token
 Clears the access token stored by Connect-AzRetirementMonitor. This does not affect 
 your Azure CLI or Az.Accounts session - you remain logged in to Azure after disconnecting.
 
-The token is cleared from memory by setting the module-scoped variable to $null.
-Since PowerShell access tokens are session-based and time-limited, this is sufficient
-for cleanup. The token cannot be recovered after clearing.
+The SecureString token reference is cleared from module scope. PowerShell does not
+provide deterministic memory clearing for managed strings created while preparing
+HTTP headers.
 .EXAMPLE
 Disconnect-AzRetirementMonitor
 Clears the stored access token
@@ -20,14 +20,10 @@ None. Displays a success message when disconnection completes.
     [OutputType([void])]
     param()
 
-    if ($script:AccessToken) {
-        # Clear the token from memory
-        # Note: PowerShell doesn't have secure string clearing for regular strings,
-        # but since these are time-limited session tokens (not long-lived credentials),
-        # setting to $null is acceptable. The token will be garbage collected.
-        $script:AccessToken = $null
+    if ($script:AccessTokenSecureString) {
+        $script:AccessTokenSecureString = $null
         Write-Host "Disconnected from AzRetirementMonitor successfully"
-        Write-Verbose "Access token cleared from module memory"
+        Write-Verbose "Secure access token reference cleared from module memory"
     }
     else {
         Write-Verbose "No active connection to disconnect"

--- a/Public/Get-AzRetirementMetadataItem.ps1
+++ b/Public/Get-AzRetirementMetadataItem.ps1
@@ -16,7 +16,7 @@ https://learn.microsoft.com/rest/api/advisor/metadata
     [CmdletBinding()]
     param()
 
-    if (-not $script:AccessToken) {
+    if (-not $script:AccessTokenSecureString) {
         throw "Not authenticated. Run Connect-AzRetirementMonitor -UsingAPI first. Note: This function requires API access as Az.Advisor module does not expose metadata cmdlets."
     }
 
@@ -24,6 +24,7 @@ https://learn.microsoft.com/rest/api/advisor/metadata
         throw "Access token has expired. Run Connect-AzRetirementMonitor -UsingAPI again."
     }
 
+    $credential = New-Object System.Management.Automation.PSCredential("token", $script:AccessTokenSecureString)
     $headers = @{
         Authorization  = "Bearer $script:AccessToken"
         "Content-Type" = "application/json"

--- a/Public/Get-AzRetirementRecommendation.ps1
+++ b/Public/Get-AzRetirementRecommendation.ps1
@@ -49,7 +49,7 @@ Gets recommendations using the REST API method
 
         if ($UseAPI) {
             # API mode - requires authentication via Connect-AzRetirementMonitor
-            if (-not $script:AccessToken) {
+            if (-not $script:AccessTokenSecureString) {
                 throw "Not authenticated. Run Connect-AzRetirementMonitor -UsingAPI first."
             }
 
@@ -57,6 +57,7 @@ Gets recommendations using the REST API method
                 throw "Access token has expired. Run Connect-AzRetirementMonitor -UsingAPI again."
             }
 
+            $credential = New-Object System.Management.Automation.PSCredential("token", $script:AccessTokenSecureString)
             $headers = @{
                 Authorization  = "Bearer $script:AccessToken"
                 "Content-Type" = "application/json"

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Connect-AzRetirementMonitor -UsingAPI -UseAzPowerShell
 
 Clears the access token stored by the module. This does not affect your Azure CLI or Az.Accounts session - you remain logged in to Azure.
 
-The token reference is cleared from module memory when you disconnect. Note that PowerShell module scope is not a security boundary — other code running in the same session can access module-scoped variables. Use `Disconnect-AzRetirementMonitor` when done, and avoid running untrusted scripts in the same session.
+The `SecureString` token reference is cleared from module memory when you disconnect. Note that PowerShell module scope is not a security boundary — other code running in the same session can access the reference and a malicious same-session process may decrypt it. Use `Disconnect-AzRetirementMonitor` when done, and avoid running untrusted scripts in the same session.
 
 **Only relevant when using API mode.**
 
@@ -370,9 +370,9 @@ The API method uses a **read-only, scoped token** approach to ensure security an
    - **Az.Accounts**: Uses `Get-AzAccessToken` to request a token from your connected context
    - The module does **not** prompt for credentials or re-authenticate you
 
-2. **Token Storage**: The token is stored in a **module-scoped variable** (`$script:AccessToken`):
-   - Only accessible within the AzRetirementMonitor module
-   - Not accessible to other PowerShell modules or sessions
+2. **Token Storage**: The token is stored as a **`SecureString` in module scope** (`$script:AccessTokenSecureString`):
+   - Plaintext is not retained in the module-scoped variable
+   - Plaintext exists only transiently while preparing REST request headers
    - Automatically cleared when the module is unloaded
    - Can be manually cleared with `Disconnect-AzRetirementMonitor`
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -57,9 +57,10 @@ This security policy covers the PowerShell source code in this repository. It do
 
 ## Token Storage Considerations
 
-When using API mode (`Connect-AzRetirementMonitor -UsingAPI`), the access token is stored as a module-scoped variable for the duration of the session. Be aware of the following:
+When using API mode (`Connect-AzRetirementMonitor -UsingAPI`), the access token is retained as a `SecureString` in module scope for the duration of the session. Be aware of the following:
 
-- **Module scope is not a security boundary.** Any code running in the same PowerShell session can access module-scoped variables via `& (Get-Module ModuleName) { $script:Variable }`. Do not run untrusted scripts alongside this module when authenticated.
+- **Module scope is not a security boundary.** Any code running in the same PowerShell session can access the `SecureString` reference via `& (Get-Module ModuleName) { $script:AccessTokenSecureString }`. This prevents casual plaintext recovery but is not a defense against a fully malicious same-session process that can invoke decryption APIs. Do not run untrusted scripts alongside this module when authenticated.
+- **Transient plaintext.** REST APIs require a string Authorization header, so plaintext exists briefly while each request is prepared. PowerShell does not provide deterministic memory clearing for those managed strings.
 - **Token lifetime.** The token is a short-lived Azure access token (typically 60–90 minutes). It is scoped to `https://management.azure.com` with read-only permissions.
-- **Clearing the token.** `Disconnect-AzRetirementMonitor` sets the variable to `$null`, but the string may remain in managed memory until garbage collected. PowerShell does not offer deterministic memory clearing for strings.
+- **Clearing the token.** `Disconnect-AzRetirementMonitor` clears the module's `SecureString` reference. Any transient header strings may remain in managed memory until garbage collected.
 - **Best practice.** Run `Disconnect-AzRetirementMonitor` when finished, and prefer isolated sessions or dedicated automation accounts for sensitive environments.

--- a/Tests/AzRetirementMonitor.Tests.ps1
+++ b/Tests/AzRetirementMonitor.Tests.ps1
@@ -75,7 +75,7 @@ Describe "Connect-AzRetirementMonitor SecureString Handling" {
     BeforeEach {
         # Clear the token before each test
         $module = Get-Module AzRetirementMonitor
-        & $module { $script:AccessToken = $null }
+        & $module { $script:AccessTokenSecureString = $null }
 
         # Common mocks for Az.Accounts and Azure context used across tests
         Mock -ModuleName AzRetirementMonitor Get-Module -ParameterFilter { $Name -eq 'Az.Accounts' -and $ListAvailable } {
@@ -95,7 +95,7 @@ Describe "Connect-AzRetirementMonitor SecureString Handling" {
     }
     
     Context "Az.Accounts 5.0+ with SecureString Token" {
-        It "Should convert SecureString token to plain text" {
+        It "Should retain SecureString token without plaintext module storage" {
             # Create a SecureString token to simulate Az.Accounts 5.0+ behavior
             $secureToken = ConvertTo-SecureString -String $script:TestToken -AsPlainText -Force
             
@@ -112,16 +112,15 @@ Describe "Connect-AzRetirementMonitor SecureString Handling" {
             
             # Verify the token was set correctly in module scope
             $module = Get-Module AzRetirementMonitor
-            $storedToken = & $module { $script:AccessToken }
+            $storedToken = & $module { $script:AccessTokenSecureString }
             
             # The stored token should be the plain text version
-            $storedToken | Should -Be $script:TestToken
-            $storedToken | Should -BeOfType [string]
+            $storedToken | Should -BeOfType [System.Security.SecureString]
         }
     }
     
     Context "Older Az.Accounts with Plain Text Token" {
-        It "Should use plain text token directly" {
+        It "Should convert legacy plain text token into SecureString storage" {
             # Mock Get-AzAccessToken to return a token object with plain text Token property
             Mock -ModuleName AzRetirementMonitor Get-AzAccessToken {
                 return [PSCustomObject]@{
@@ -135,11 +134,10 @@ Describe "Connect-AzRetirementMonitor SecureString Handling" {
             
             # Verify the token was set correctly in module scope
             $module = Get-Module AzRetirementMonitor
-            $storedToken = & $module { $script:AccessToken }
+            $storedToken = & $module { $script:AccessTokenSecureString }
             
             # The stored token should be the plain text version
-            $storedToken | Should -Be $script:TestToken
-            $storedToken | Should -BeOfType [string]
+            $storedToken | Should -BeOfType [System.Security.SecureString]
         }
     }
 }
@@ -165,7 +163,7 @@ Describe "Connect-AzRetirementMonitor Token Validation" {
 
     BeforeEach {
         $module = Get-Module AzRetirementMonitor
-        & $module { $script:AccessToken = $null }
+        & $module { $script:AccessTokenSecureString = $null }
     }
 
     Context "Azure CLI path returns empty token" {
@@ -180,7 +178,7 @@ Describe "Connect-AzRetirementMonitor Token Validation" {
             $connectError[0].Exception.Message | Should -BeLike "*Failed to acquire access token*"
 
             $module = Get-Module AzRetirementMonitor
-            $storedToken = & $module { $script:AccessToken }
+            $storedToken = & $module { $script:AccessTokenSecureString }
             $storedToken | Should -BeNullOrEmpty
         }
     }
@@ -206,7 +204,7 @@ Describe "Connect-AzRetirementMonitor Token Validation" {
             $connectError[0].Exception.Message | Should -BeLike "*Failed to acquire access token*"
 
             $module = Get-Module AzRetirementMonitor
-            $storedToken = & $module { $script:AccessToken }
+            $storedToken = & $module { $script:AccessTokenSecureString }
             $storedToken | Should -BeNullOrEmpty
         }
     }
@@ -216,30 +214,30 @@ Describe "Disconnect-AzRetirementMonitor" {
     BeforeEach {
         # Clear the token before each test
         $module = Get-Module AzRetirementMonitor
-        & $module { $script:AccessToken = $null }
+        & $module { $script:AccessTokenSecureString = $null }
     }
     
     It "Should clear the access token when connected" {
         # Set up a token
         $module = Get-Module AzRetirementMonitor
-        & $module { $script:AccessToken = "test-token-value" }
+        & $module { $script:AccessTokenSecureString = ConvertTo-SecureString "test-token-value" -AsPlainText -Force }
         
         # Verify token is set
-        $tokenBefore = & $module { $script:AccessToken }
-        $tokenBefore | Should -Be "test-token-value"
+        $tokenBefore = & $module { $script:AccessTokenSecureString }
+        $tokenBefore | Should -BeOfType [System.Security.SecureString]
         
         # Disconnect
         Disconnect-AzRetirementMonitor
         
         # Verify token is cleared
-        $tokenAfter = & $module { $script:AccessToken }
+        $tokenAfter = & $module { $script:AccessTokenSecureString }
         $tokenAfter | Should -BeNullOrEmpty
     }
     
     It "Should handle disconnecting when not connected" {
         # Ensure no token is set
         $module = Get-Module AzRetirementMonitor
-        & $module { $script:AccessToken = $null }
+        & $module { $script:AccessTokenSecureString = $null }
         
         # Should not throw
         { Disconnect-AzRetirementMonitor } | Should -Not -Throw
@@ -643,7 +641,7 @@ Describe "Token Expiration Validation" {
     BeforeEach {
         # Clear the token without reimporting the entire module
         $module = Get-Module AzRetirementMonitor
-        & $module { $script:AccessToken = $null }
+        & $module { $script:AccessTokenSecureString = $null }
     }
     
     It "Get-AzRetirementMetadataItem should throw when not authenticated" {
@@ -661,7 +659,7 @@ Describe "Token Expiration Validation" {
         
         # Access the module's script scope to set the token
         $module = Get-Module AzRetirementMonitor
-        & $module { param($token) $script:AccessToken = $token } $expiredToken
+        & $module { param($token) $script:AccessTokenSecureString = ConvertTo-SecureString $token -AsPlainText -Force } $expiredToken
         
         { Get-AzRetirementMetadataItem -ErrorAction Stop } | Should -Throw "*expired*"
     }
@@ -673,7 +671,7 @@ Describe "Token Expiration Validation" {
         
         # Access the module's script scope to set the token
         $module = Get-Module AzRetirementMonitor
-        & $module { param($token) $script:AccessToken = $token } $expiredToken
+        & $module { param($token) $script:AccessTokenSecureString = ConvertTo-SecureString $token -AsPlainText -Force } $expiredToken
         
         { Get-AzRetirementRecommendation -UseAPI -ErrorAction Stop } | Should -Throw "*expired*"
     }
@@ -685,7 +683,7 @@ Describe "Token Expiration Validation" {
         
         # Access the module's script scope to set the token and test it
         $module = Get-Module AzRetirementMonitor
-        & $module { param($token) $script:AccessToken = $token } $validToken
+        & $module { param($token) $script:AccessTokenSecureString = ConvertTo-SecureString $token -AsPlainText -Force } $validToken
         
         # Call the private Test function to verify the token is valid
         $testResult = & $module { Test-AzRetirementMonitorToken }
@@ -697,7 +695,7 @@ Describe "Token Expiration Validation" {
         $malformedToken = "header.payload"
         
         $module = Get-Module AzRetirementMonitor
-        & $module { param($token) $script:AccessToken = $token } $malformedToken
+        & $module { param($token) $script:AccessTokenSecureString = ConvertTo-SecureString $token -AsPlainText -Force } $malformedToken
         
         $testResult = & $module { Test-AzRetirementMonitorToken }
         $testResult | Should -Be $false
@@ -711,7 +709,7 @@ Describe "Token Expiration Validation" {
         $malformedToken = "$header.$invalidPayload.$signature"
         
         $module = Get-Module AzRetirementMonitor
-        & $module { param($token) $script:AccessToken = $token } $malformedToken
+        & $module { param($token) $script:AccessTokenSecureString = ConvertTo-SecureString $token -AsPlainText -Force } $malformedToken
         
         $testResult = & $module { Test-AzRetirementMonitorToken }
         $testResult | Should -Be $false
@@ -731,7 +729,7 @@ Describe "Token Expiration Validation" {
         $tokenNoExp = "$header.$payload.$signature"
         
         $module = Get-Module AzRetirementMonitor
-        & $module { param($token) $script:AccessToken = $token } $tokenNoExp
+        & $module { param($token) $script:AccessTokenSecureString = ConvertTo-SecureString $token -AsPlainText -Force } $tokenNoExp
         
         $testResult = & $module { Test-AzRetirementMonitorToken }
         $testResult | Should -Be $false
@@ -770,14 +768,14 @@ Describe "Token Audience Validation" {
     BeforeEach {
         # Clear the token before each test
         $module = Get-Module AzRetirementMonitor
-        & $module { $script:AccessToken = $null }
+        & $module { $script:AccessTokenSecureString = $null }
     }
     
     It "Should accept token with https://management.azure.com audience" {
         $token = New-TestTokenWithAudience -Audience "https://management.azure.com"
         
         $module = Get-Module AzRetirementMonitor
-        & $module { param($token) $script:AccessToken = $token } $token
+        & $module { param($token) $script:AccessTokenSecureString = ConvertTo-SecureString $token -AsPlainText -Force } $token
         
         $testResult = & $module { Test-AzRetirementMonitorToken }
         $testResult | Should -Be $true
@@ -787,7 +785,7 @@ Describe "Token Audience Validation" {
         $token = New-TestTokenWithAudience -Audience "https://management.azure.com/"
         
         $module = Get-Module AzRetirementMonitor
-        & $module { param($token) $script:AccessToken = $token } $token
+        & $module { param($token) $script:AccessTokenSecureString = ConvertTo-SecureString $token -AsPlainText -Force } $token
         
         $testResult = & $module { Test-AzRetirementMonitorToken }
         $testResult | Should -Be $true
@@ -798,7 +796,7 @@ Describe "Token Audience Validation" {
         $token = New-TestTokenWithAudience -Audience "https://management.core.windows.net"
         
         $module = Get-Module AzRetirementMonitor
-        & $module { param($token) $script:AccessToken = $token } $token
+        & $module { param($token) $script:AccessTokenSecureString = ConvertTo-SecureString $token -AsPlainText -Force } $token
         
         $testResult = & $module { Test-AzRetirementMonitorToken }
         $testResult | Should -Be $true
@@ -808,7 +806,7 @@ Describe "Token Audience Validation" {
         $token = New-TestTokenWithAudience -Audience "https://graph.microsoft.com"
         
         $module = Get-Module AzRetirementMonitor
-        & $module { param($token) $script:AccessToken = $token } $token
+        & $module { param($token) $script:AccessTokenSecureString = ConvertTo-SecureString $token -AsPlainText -Force } $token
         
         $testResult = & $module { Test-AzRetirementMonitorToken }
         $testResult | Should -Be $false
@@ -818,7 +816,7 @@ Describe "Token Audience Validation" {
         $token = New-TestTokenWithAudience -Audience "https://example.com"
         
         $module = Get-Module AzRetirementMonitor
-        & $module { param($token) $script:AccessToken = $token } $token
+        & $module { param($token) $script:AccessTokenSecureString = ConvertTo-SecureString $token -AsPlainText -Force } $token
         
         $testResult = & $module { Test-AzRetirementMonitorToken }
         $testResult | Should -Be $false
@@ -838,7 +836,7 @@ Describe "Token Audience Validation" {
         $tokenNoAud = "$header.$payload.$signature"
         
         $module = Get-Module AzRetirementMonitor
-        & $module { param($token) $script:AccessToken = $token } $tokenNoAud
+        & $module { param($token) $script:AccessTokenSecureString = ConvertTo-SecureString $token -AsPlainText -Force } $tokenNoAud
         
         $testResult = & $module { Test-AzRetirementMonitorToken }
         $testResult | Should -Be $false


### PR DESCRIPTION
## Summary

Closes #25.

- Store API access tokens as `SecureString` values in module scope instead of plaintext strings.
- Materialize plaintext only transiently when `Invoke-AzPagedRequest` prepares the REST `Authorization` header.
- Preserve Azure CLI and Az.Accounts authentication behavior, including legacy plain-text `Get-AzAccessToken` responses.
- Clear the secure token reference on disconnect and update tests, README, SECURITY.md, and CHANGELOG.md.

## Security tradeoffs

This prevents casual recovery of the token as a plaintext module variable. PowerShell module scope remains accessible to code in the same session, and a malicious same-session process can invoke SecureString decryption APIs. REST headers also require transient plaintext strings, which PowerShell cannot deterministically clear from managed memory. The documentation now states these limitations; isolated sessions remain recommended for untrusted workloads.

## Validation

- `Invoke-Pester ./Tests/AzRetirementMonitor.Tests.ps1`
- 68 tests passed, 0 failed
