### PR TITLE
Fix duplicate Advisor ExtendedProperty parsing

### DIFF
--- a/Private/Get-AzAdvisorExtendedProperty.ps1
+++ b/Private/Get-AzAdvisorExtendedProperty.ps1
@@ -1,0 +1,34 @@
+function Get-AzAdvisorExtendedProperty {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [object]$Recommendation
+    )
+
+    if ($Recommendation.PSObject.Properties.Name -contains 'ExtendedPropertyObject') {
+        return $Recommendation.ExtendedPropertyObject
+    }
+
+    $extendedPropertyObject = $null
+    if ($Recommendation.ExtendedProperty) {
+        try {
+            if ($Recommendation.ExtendedProperty -is [string]) {
+                $extendedPropertyObject = $Recommendation.ExtendedProperty | ConvertFrom-Json
+            }
+            else {
+                # Az.Advisor versions can return an already-materialized property object.
+                $extendedPropertyObject = $Recommendation.ExtendedProperty
+            }
+        }
+        catch {
+            Write-Verbose "Failed to parse ExtendedProperty: $_"
+        }
+    }
+
+    $Recommendation | Add-Member `
+        -NotePropertyName ExtendedPropertyObject `
+        -NotePropertyValue $extendedPropertyObject `
+        -Force
+
+    return $extendedPropertyObject
+}

--- a/Public/Get-AzRetirementRecommendation.ps1
+++ b/Public/Get-AzRetirementRecommendation.ps1
@@ -171,14 +171,8 @@ Gets recommendations using the REST API method
 
                 # Common filter for ServiceUpgradeAndRetirement subcategory
                 $subcategoryFilter = {
-                    # Parse extended properties to check subcategory
-                    if ($_.ExtendedProperty) {
-                        $extProps = $_.ExtendedProperty | ConvertFrom-Json
-                        $extProps.recommendationSubCategory -eq 'ServiceUpgradeAndRetirement'
-                    }
-                    else {
-                        $false
-                    }
+                    $extProps = Get-AzAdvisorExtendedProperty -Recommendation $_
+                    $extProps -and $extProps.recommendationSubCategory -eq 'ServiceUpgradeAndRetirement'
                 }
                 
                 $recommendations = if ($SubscriptionId) {
@@ -232,41 +226,13 @@ Gets recommendations using the REST API method
 
                 foreach ($rec in $recommendations) {
                     # Parse extended properties for retirement information
-                    $extProps = $null
+                    $extProps = Get-AzAdvisorExtendedProperty -Recommendation $rec
                     $retirementFeatureName = $null
                     $retirementDate = $null
 
-                    if ($rec.ExtendedProperty) {
-                        # Reuse a previously-parsed ExtendedProperty if available to avoid redundant JSON parsing
-                        if ($rec.PSObject.Properties.Name -contains 'ExtendedPropertyObject') {
-                            $extProps = $rec.ExtendedPropertyObject
-                        }
-                        else {
-                            try {
-                                if ($rec.ExtendedProperty -is [string]) {
-                                    # ExtendedProperty is JSON text; parse it once
-                                    $extProps = $rec.ExtendedProperty | ConvertFrom-Json
-                                }
-                                elseif ($rec.ExtendedProperty -is [hashtable] -or $rec.ExtendedProperty -is [pscustomobject]) {
-                                    # ExtendedProperty is already an object; no need to parse
-                                    $extProps = $rec.ExtendedProperty
-                                }
-
-                                if ($extProps) {
-                                    # Cache the parsed object on the recommendation to prevent re-parsing
-                                    $rec | Add-Member -NotePropertyName ExtendedPropertyObject -NotePropertyValue $extProps -Force
-                                }
-                            }
-                            catch {
-                                Write-Verbose "Failed to parse ExtendedProperty: $_"
-                                $extProps = $null
-                            }
-                        }
-
-                        if ($extProps) {
-                            $retirementFeatureName = $extProps.retirementFeatureName
-                            $retirementDate = $extProps.retirementDate
-                        }
+                    if ($extProps) {
+                        $retirementFeatureName = $extProps.retirementFeatureName
+                        $retirementDate = $extProps.retirementDate
                     }
 
                     # Check if this is a retirement recommendation

--- a/Tests/AzRetirementMonitor.Tests.ps1
+++ b/Tests/AzRetirementMonitor.Tests.ps1
@@ -371,6 +371,65 @@ Describe "Get-AzRetirementRecommendation Context Switching Logic" {
     }
 }
 
+Describe "Get-AzRetirementRecommendation ExtendedProperty handling" {
+    BeforeEach {
+        Mock -ModuleName AzRetirementMonitor Test-AzAdvisorSession { $true }
+        Mock -ModuleName AzRetirementMonitor Get-AzAdvisorRecommendation {
+            [PSCustomObject]@{
+                ExtendedProperty = '{"recommendationSubCategory":"ServiceUpgradeAndRetirement","retirementFeatureName":"Test feature"}'
+                ShortDescriptionProblem = "Service retirement"
+                ShortDescriptionSolution = "Upgrade the service"
+                ResourceMetadataResourceId = "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/test-vm"
+                Category = "HighAvailability"
+                Impact = "High"
+                LastUpdated = "2026-01-01"
+                Name = "recommendation-1"
+                LearnMoreLink = "https://learn.microsoft.com"
+            }
+        }
+    }
+
+    It "Should parse string ExtendedProperty once and reuse the cached object" {
+        Mock -ModuleName AzRetirementMonitor ConvertFrom-Json {
+            [PSCustomObject]@{
+                recommendationSubCategory = "ServiceUpgradeAndRetirement"
+                retirementFeatureName = "Test feature"
+            }
+        }
+
+        $result = @(Get-AzRetirementRecommendation)
+
+        Should -Invoke -ModuleName AzRetirementMonitor ConvertFrom-Json -Times 1 -Exactly
+        $result.Count | Should -Be 1
+        $result[0].Description | Should -Be "Test feature"
+    }
+
+    It "Should reuse an already-materialized ExtendedProperty without JSON parsing" {
+        Mock -ModuleName AzRetirementMonitor Get-AzAdvisorRecommendation {
+            [PSCustomObject]@{
+                ExtendedProperty = [PSCustomObject]@{
+                    recommendationSubCategory = "ServiceUpgradeAndRetirement"
+                    retirementFeatureName = "Materialized feature"
+                }
+                ShortDescriptionProblem = "Service retirement"
+                ShortDescriptionSolution = "Upgrade the service"
+                ResourceMetadataResourceId = "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/test-vm"
+                Category = "HighAvailability"
+                Impact = "High"
+                LastUpdated = "2026-01-01"
+                Name = "recommendation-2"
+                LearnMoreLink = "https://learn.microsoft.com"
+            }
+        }
+        Mock -ModuleName AzRetirementMonitor ConvertFrom-Json { throw "ConvertFrom-Json should not be called" }
+
+        $result = @(Get-AzRetirementRecommendation)
+
+        $result.Count | Should -Be 1
+        $result[0].Description | Should -Be "Materialized feature"
+    }
+}
+
 Describe "Get-AzRetirementMetadataItem" {
     It "Should have no parameters" {
         $cmd = Get-Command Get-AzRetirementMetadataItem


### PR DESCRIPTION
## Summary

Resolves #28 by caching the parsed `ExtendedProperty` value on each Az.Advisor recommendation. The subcategory filter and output mapping now use the same private helper, so each recommendation parses JSON at most once. Already-materialized property objects are reused without JSON parsing, and failed/empty parses are cached as null to avoid repeated work.

## Compatibility and behavior

- Preserves PowerShell 5.1 and PowerShell 7+ syntax and behavior.
- Keeps the existing subcategory and retirement detection behavior.
- Handles both JSON string and already-materialized `ExtendedProperty` values.
- No live Azure authentication is required.

## Tests

- `Invoke-Pester ./Tests/AzRetirementMonitor.Tests.ps1`
- 70 passed, 0 failed
- Added focused coverage for one JSON parse with cache reuse and zero JSON parses for materialized properties.