### PR TITLE
Use static shells in CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,19 @@ jobs:
           Write-Host "PowerShell version: $($PSVersionTable.PSVersion)"
           Write-Host "PSEdition: $($PSVersionTable.PSEdition)"
 
+      - name: Verify expected PowerShell Core
+        shell: pwsh
+        run: |
+          if ($PSVersionTable.PSEdition -ne 'Core') {
+            Write-Error "Expected PSEdition 'Core' but got '$($PSVersionTable.PSEdition)'"
+            exit 1
+          }
+          if ($PSVersionTable.PSVersion.Major -lt 6) {
+            Write-Error "Expected PowerShell 6 or later but got $($PSVersionTable.PSVersion)"
+            exit 1
+          }
+          Write-Host "Confirmed: PowerShell Core $($PSVersionTable.PSVersion)"
+
       - name: Install Pester
         shell: pwsh
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,8 @@ jobs:
             Write-Host "No issues found by PSScriptAnalyzer"
           }
 
-  test:
-    name: Test (${{ matrix.os }}, ${{ matrix.shell }})
+  test-pwsh:
+    name: Test (${{ matrix.os }}, pwsh)
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -49,25 +49,57 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        shell: [pwsh, powershell]
-        exclude:
-          - os: ubuntu-latest
-            shell: powershell
-          - os: windows-latest
-            shell: pwsh
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Print PowerShell version
-        shell: ${{ matrix.shell }}
+        shell: pwsh
+        run: |
+          Write-Host "PowerShell version: $($PSVersionTable.PSVersion)"
+          Write-Host "PSEdition: $($PSVersionTable.PSEdition)"
+
+      - name: Install Pester
+        shell: pwsh
+        run: |
+          Set-PSRepository PSGallery -InstallationPolicy Trusted
+          Install-Module -Name Pester -MinimumVersion 5.0.0 -MaximumVersion 5.99.99 -Force -Scope CurrentUser -SkipPublisherCheck
+
+      - name: Run Pester Tests
+        shell: pwsh
+        run: |
+          Import-Module Pester -MinimumVersion 5.0.0 -MaximumVersion 5.99.99
+          Write-Host "Pester version: $((Get-Module Pester).Version)"
+          $testPath = "Tests/AzRetirementMonitor.Tests.ps1"
+          if (Test-Path $testPath) {
+            $config = New-PesterConfiguration
+            $config.Run.Path = $testPath
+            $config.Run.Exit = $true
+            $config.Output.Verbosity = 'Detailed'
+            Invoke-Pester -Configuration $config
+          } else {
+            Write-Error "Test file not found at: $testPath"
+            exit 1
+          }
+
+  test-powershell:
+    name: Test (windows-latest, Windows PowerShell)
+    runs-on: windows-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Print PowerShell version
+        shell: powershell
         run: |
           Write-Host "PowerShell version: $($PSVersionTable.PSVersion)"
           Write-Host "PSEdition: $($PSVersionTable.PSEdition)"
 
       - name: Verify expected PowerShell edition
-        if: ${{ matrix.shell == 'powershell' }}
         shell: powershell
         run: |
           if ($PSVersionTable.PSEdition -ne 'Desktop') {
@@ -81,13 +113,13 @@ jobs:
           Write-Host "Confirmed: Windows PowerShell $($PSVersionTable.PSVersion) Desktop"
 
       - name: Install Pester
-        shell: ${{ matrix.shell }}
+        shell: powershell
         run: |
           Set-PSRepository PSGallery -InstallationPolicy Trusted
           Install-Module -Name Pester -MinimumVersion 5.0.0 -MaximumVersion 5.99.99 -Force -Scope CurrentUser -SkipPublisherCheck
 
       - name: Run Pester Tests
-        shell: ${{ matrix.shell }}
+        shell: powershell
         run: |
           Import-Module Pester -MinimumVersion 5.0.0 -MaximumVersion 5.99.99
           Write-Host "Pester version: $((Get-Module Pester).Version)"


### PR DESCRIPTION
This pull request restructures the test jobs in the GitHub Actions workflow to improve clarity and reliability when running tests across different PowerShell environments. The main change is splitting the previous matrix-based test job into two explicit jobs: one for PowerShell Core (`pwsh`) on both Ubuntu and Windows, and one for Windows PowerShell (`powershell`) on Windows only. This also simplifies the logic and shell selection in the workflow steps.

**Test workflow improvements:**

* Split the previous matrix-based `test` job into two explicit jobs: `test-pwsh` (runs on both Ubuntu and Windows with PowerShell Core) and `test-powershell` (runs on Windows with Windows PowerShell), removing unnecessary matrix logic and exclusions.
* Updated all test job steps to use explicit shell declarations (`pwsh` or `powershell`) instead of referencing the matrix variable, reducing complexity and potential errors. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL43-L70) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL84-R122)
* Each test job now installs and runs Pester tests in a more robust way, including version checks and improved error handling if the test file is missing.

**Simplification and clarity:**

* Removed the shell matrix and exclusion logic, making it clearer which shells and operating systems are being tested.
* Ensured that all PowerShell version and edition checks are run in the appropriate shell for each job. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL43-L70) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL84-R122)