### PR TITLE
Fix Advisor retirement recommendation filtering

### DIFF
--- a/AzRetirementMonitor.psd1
+++ b/AzRetirementMonitor.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule           = 'AzRetirementMonitor.psm1'
-    ModuleVersion        = '3.0.0'
+    ModuleVersion        = '3.0.1'
     GUID                 = '6775bae9-a3ec-43de-abd9-14308dd345c4'
     Author               = 'Corey Callaway'
     CompanyName          = 'Independent'
@@ -22,13 +22,9 @@
             LicenseUri = 'https://github.com/cocallaw/AzRetirementMonitor/blob/main/LICENSE'
             ProjectUri = 'https://github.com/cocallaw/AzRetirementMonitor'
             ReleaseNotes = @'
-## Version 3.0.0
-- Adds `-Stream` for low-memory, pipeline-first recommendation retrieval.
-- Adds retry with exponential backoff for transient Azure Resource Manager throttling.
-- Validates pagination links before following them to prevent token forwarding to untrusted hosts.
-- Stores API tokens as `SecureString` values in module scope and clears them on disconnect.
-- Caches parsed Advisor extended properties during recommendation filtering.
-- Adds output path validation and preserves CSV formula-injection and HTML/XSS protections.
+## Version 3.0.1
+- Fixes Az.Advisor retirement recommendation filtering when extended properties are exposed through `AdditionalProperties`.
+- Preserves support for JSON strings, dictionaries, materialized objects, and cached extended properties.
 '@
         }
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1] - 2026-08-08
+
+### Fixed
+- Az.Advisor retirement recommendations are no longer filtered out when generated model objects expose extended fields through `AdditionalProperties`.
+
 ## [3.0.0] - 2026-08-05
 
 ### Added
@@ -80,6 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Export-AzRetirementReport` for CSV and JSON export
 - Pagination support for Azure REST API responses
 
+[3.0.1]: https://github.com/cocallaw/AzRetirementMonitor/compare/v3.0.0...v3.0.1
 [3.0.0]: https://github.com/cocallaw/AzRetirementMonitor/compare/v2.0.0...v3.0.0
 [2.0.0]: https://github.com/cocallaw/AzRetirementMonitor/compare/v1.2.1...v2.0.0
 [1.2.1]: https://github.com/cocallaw/AzRetirementMonitor/compare/v1.2.0...v1.2.1

--- a/Private/Get-AzAdvisorExtendedProperty.ps1
+++ b/Private/Get-AzAdvisorExtendedProperty.ps1
@@ -5,19 +5,29 @@ function Get-AzAdvisorExtendedProperty {
         [object]$Recommendation
     )
 
-    if ($Recommendation.PSObject.Properties.Name -contains 'ExtendedPropertyObject') {
+    if (
+        $Recommendation.PSObject.Properties.Name -contains 'ExtendedPropertyObject' -and
+        $null -ne $Recommendation.ExtendedPropertyObject
+    ) {
         return $Recommendation.ExtendedPropertyObject
     }
 
+    $extendedProperty = if ($Recommendation.PSObject.Properties.Name -contains 'ExtendedProperty') {
+        $Recommendation.ExtendedProperty
+    }
+    elseif ($Recommendation.PSObject.Properties.Name -contains 'ExtendedProperties') {
+        $Recommendation.ExtendedProperties
+    }
+
     $extendedPropertyObject = $null
-    if ($Recommendation.ExtendedProperty) {
+    if ($extendedProperty) {
         try {
-            if ($Recommendation.ExtendedProperty -is [string]) {
-                $extendedPropertyObject = $Recommendation.ExtendedProperty | ConvertFrom-Json
+            if ($extendedProperty -is [string]) {
+                $extendedPropertyObject = $extendedProperty | ConvertFrom-Json
             }
             else {
                 # Az.Advisor versions can return an already-materialized property object.
-                $extendedPropertyObject = $Recommendation.ExtendedProperty
+                $extendedPropertyObject = $extendedProperty
             }
         }
         catch {

--- a/Private/Get-AzAdvisorExtendedProperty.ps1
+++ b/Private/Get-AzAdvisorExtendedProperty.ps1
@@ -25,6 +25,13 @@ function Get-AzAdvisorExtendedProperty {
             if ($extendedProperty -is [string]) {
                 $extendedPropertyObject = $extendedProperty | ConvertFrom-Json
             }
+            elseif (
+                $extendedProperty.PSObject.Properties.Name -contains 'AdditionalProperties' -and
+                $null -ne $extendedProperty.AdditionalProperties
+            ) {
+                # Generated Az.Advisor models expose custom fields through this dictionary.
+                $extendedPropertyObject = $extendedProperty.AdditionalProperties
+            }
             else {
                 # Az.Advisor versions can return an already-materialized property object.
                 $extendedPropertyObject = $extendedProperty

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Azure services evolve constantly, with features, APIs, and entire services being
 
 **AzRetirementMonitor** helps you proactively identify Azure resources affected by upcoming retirements by querying Azure Advisor for service upgrade and retirement recommendations across all your subscriptions. This gives you time to plan migrations and upgrades before services are discontinued.
 
-## 🚀 Version 3.0.0
+## 🚀 Version 3.0.1
 
-**Version 3.0.0 builds on the Az.Advisor-first workflow introduced in v2.0.0:**
+**Version 3.0.1 builds on the Az.Advisor-first workflow introduced in v2.0.0:**
 
 - **Default behavior**: Uses Az.Advisor PowerShell module (full parity with Azure Advisor)
 - **API mode**: Available via `-UseAPI` switch on Get-AzRetirementRecommendation

--- a/Tests/AzRetirementMonitor.Tests.ps1
+++ b/Tests/AzRetirementMonitor.Tests.ps1
@@ -492,6 +492,51 @@ Describe "Get-AzRetirementRecommendation ExtendedProperty handling" {
         $result[0].Description | Should -Be "Dictionary feature"
     }
 
+    It "Should filter Az.Advisor associative extended properties by subcategory" {
+        $retirementProperties = [System.Collections.Generic.Dictionary[string,string]]::new()
+        $retirementProperties['recommendationSubCategory'] = 'ServiceUpgradeAndRetirement'
+        $retirementProperties['retirementFeatureName'] = 'Operating System (OS) Disks on Standard HDD'
+        $retirementProperties['retirementDate'] = '2028-09-08'
+
+        $scalabilityProperties = [System.Collections.Generic.Dictionary[string,string]]::new()
+        $scalabilityProperties['recommendationSubCategory'] = 'Scalability'
+
+        Mock -ModuleName AzRetirementMonitor Get-AzAdvisorRecommendation {
+            @(
+                [PSCustomObject]@{
+                    ExtendedProperty = [PSCustomObject]@{
+                        AdditionalProperties = $retirementProperties
+                    }
+                    ShortDescriptionProblem = "Migrate Standard HDD OS Disks to SSD"
+                    ShortDescriptionSolution = "Migrate Standard HDD OS Disks to SSD"
+                    ResourceMetadataResourceId = "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/test-rg/providers/Microsoft.Compute/disks/test-disk"
+                    Category = "HighAvailability"
+                    Impact = "Medium"
+                    LastUpdated = "2026-04-16"
+                    Name = "retirement-recommendation"
+                }
+                [PSCustomObject]@{
+                    ExtendedProperty = [PSCustomObject]@{
+                        AdditionalProperties = $scalabilityProperties
+                    }
+                    ShortDescriptionProblem = "Use NAT gateway for outbound connectivity"
+                    ShortDescriptionSolution = "Use NAT gateway for outbound connectivity"
+                    ResourceMetadataResourceId = "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet"
+                    Category = "HighAvailability"
+                    Impact = "Medium"
+                    LastUpdated = "2026-04-17"
+                    Name = "scalability-recommendation"
+                }
+            )
+        }
+
+        $result = @(Get-AzRetirementRecommendation)
+
+        $result.Count | Should -Be 1
+        $result[0].RecommendationId | Should -Be "retirement-recommendation"
+        $result[0].Description | Should -Be "Operating System (OS) Disks on Standard HDD (Retirement Date: 2028-09-08)"
+    }
+
     It "Should emit recommendations immediately when Stream is specified" {
         $result = @(Get-AzRetirementRecommendation -Stream)
 

--- a/Tests/AzRetirementMonitor.Tests.ps1
+++ b/Tests/AzRetirementMonitor.Tests.ps1
@@ -423,6 +423,27 @@ Describe "Get-AzRetirementRecommendation ExtendedProperty handling" {
         $result[0].Description | Should -Be "Test feature"
     }
 
+    It "Should parse ExtendedProperty when the cache property is null" {
+        Mock -ModuleName AzRetirementMonitor Get-AzAdvisorRecommendation {
+            [PSCustomObject]@{
+                ExtendedProperty = '{"recommendationSubCategory":"ServiceUpgradeAndRetirement","retirementFeatureName":"Cached feature"}'
+                ExtendedPropertyObject = $null
+                ShortDescriptionProblem = "Service retirement"
+                ShortDescriptionSolution = "Upgrade the service"
+                ResourceMetadataResourceId = "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/test-vm"
+                Category = "HighAvailability"
+                Impact = "High"
+                LastUpdated = "2026-01-01"
+                Name = "recommendation-cached"
+            }
+        }
+
+        $result = @(Get-AzRetirementRecommendation)
+
+        $result.Count | Should -Be 1
+        $result[0].Description | Should -Be "Cached feature"
+    }
+
     It "Should reuse an already-materialized ExtendedProperty without JSON parsing" {
         Mock -ModuleName AzRetirementMonitor Get-AzAdvisorRecommendation {
             [PSCustomObject]@{
@@ -446,6 +467,29 @@ Describe "Get-AzRetirementRecommendation ExtendedProperty handling" {
 
         $result.Count | Should -Be 1
         $result[0].Description | Should -Be "Materialized feature"
+    }
+
+    It "Should filter recommendations with dictionary or plural extended properties" {
+        Mock -ModuleName AzRetirementMonitor Get-AzAdvisorRecommendation {
+            [PSCustomObject]@{
+                ExtendedProperties = @{
+                    recommendationSubCategory = "ServiceUpgradeAndRetirement"
+                    retirementFeatureName = "Dictionary feature"
+                }
+                ShortDescriptionProblem = "Service retirement"
+                ShortDescriptionSolution = "Upgrade the service"
+                ResourceMetadataResourceId = "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/test-vm"
+                Category = "HighAvailability"
+                Impact = "High"
+                LastUpdated = "2026-01-01"
+                Name = "recommendation-3"
+            }
+        }
+
+        $result = @(Get-AzRetirementRecommendation)
+
+        $result.Count | Should -Be 1
+        $result[0].Description | Should -Be "Dictionary feature"
     }
 
     It "Should emit recommendations immediately when Stream is specified" {

--- a/Tests/AzRetirementMonitor.Tests.ps1
+++ b/Tests/AzRetirementMonitor.Tests.ps1
@@ -7,8 +7,8 @@ Describe "Module Import" {
         Get-Module AzRetirementMonitor | Should -Not -BeNull
     }
 
-    It "Should declare the v3.0.0 release version" {
-        (Get-Module AzRetirementMonitor).Version | Should -Be ([version]'3.0.0')
+    It "Should declare the v3.0.1 release version" {
+        (Get-Module AzRetirementMonitor).Version | Should -Be ([version]'3.0.1')
     }
     
     It "Should export 5 functions" {


### PR DESCRIPTION
## Summary
- normalize Az.Advisor associative extended properties through `AdditionalProperties`
- preserve existing JSON, dictionary, and cached-property handling
- add regression coverage for mixed retirement and non-retirement recommendations

## Validation
- `Invoke-Pester ./Tests/AzRetirementMonitor.Tests.ps1` (75 passed)
- PSScriptAnalyzer with PSGallery settings