### PR TITLE
Update API data parity documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ Disconnect-AzRetirementMonitor
 
 | Feature | Default (Az.Advisor) | API Method |
 |---------|---------------------|------------|
-| **Data Parity** | ✅ Full parity with Azure Portal | ⚠️ May have slight differences |
+| **Data Parity** | ✅ Full parity with Azure Portal | ✅ Full parity with Azure Portal |
 | **Authentication** | `Connect-AzAccount` | `Connect-AzRetirementMonitor -UsingAPI` |
 | **Module Required** | Az.Advisor, Az.Accounts | None (uses REST API) |
 | **Usage** | `Get-AzRetirementRecommendation` | `Get-AzRetirementRecommendation -UseAPI` |


### PR DESCRIPTION
This pull request updates the documentation for the `Disconnect-AzRetirementMonitor` feature in `README.md` to clarify the data parity status between the Az.Advisor and API methods.

Documentation update:

* The "Data Parity" row in the feature comparison table now indicates that both Az.Advisor and API methods have full parity with the Azure Portal, replacing the previous warning about possible slight differences for the API method.